### PR TITLE
[Fix] 채팅 기능 개선

### DIFF
--- a/src/main/java/com/behcm/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/behcm/domain/chat/controller/ChatController.java
@@ -1,7 +1,7 @@
 package com.behcm.domain.chat.controller;
 
+import com.behcm.domain.chat.dto.ChatHistoryResponse;
 import com.behcm.domain.chat.dto.ChatMessageRequest;
-import com.behcm.domain.chat.dto.ChatMessageResponse;
 import com.behcm.domain.chat.service.ChatService;
 import com.behcm.domain.member.entity.Member;
 import com.behcm.global.common.ApiResponse;
@@ -14,12 +14,7 @@ import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -53,13 +48,23 @@ public class ChatController {
 
     // 채팅방의 이전 대화 기록을 가져오는 API
     @GetMapping("/api/chat/rooms/{roomId}/messages")
-    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getChatHistory(
+    public ResponseEntity<ApiResponse<ChatHistoryResponse>> getChatHistory(
             @PathVariable Long roomId,
             @AuthenticationPrincipal Member member,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "20") int size
     ) {
-        List<ChatMessageResponse> response = chatService.getChatHistory(member, roomId, page, size);
+        ChatHistoryResponse response = chatService.getChatHistory(member, roomId, cursorId, size);
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 유저가 채팅을 읽었음을 서버에 알리는 API
+    @PostMapping("/api/chat/rooms/{roomId}/read")
+    public ResponseEntity<ApiResponse<Void>> updateLastReadMessage(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal Member member
+    ) {
+        chatService.updateLastReadMessage(member, roomId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/behcm/domain/chat/dto/ChatHistoryResponse.java
+++ b/src/main/java/com/behcm/domain/chat/dto/ChatHistoryResponse.java
@@ -1,0 +1,14 @@
+package com.behcm.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChatHistoryResponse {
+    private List<ChatMessageResponse> messages;
+    private Long nextCursorId; // 다음에 요청할 커서 ID
+    private boolean hasNext; // 다음 페이지 존재 여부
+}

--- a/src/main/java/com/behcm/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/behcm/domain/chat/repository/ChatMessageRepository.java
@@ -2,13 +2,29 @@ package com.behcm.domain.chat.repository;
 
 import com.behcm.domain.chat.entity.ChatMessage;
 import com.behcm.domain.workout.entity.WorkoutRoom;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     // 채팅방 ID를 기준으로 메시지를 최신순으로 페이징하여 조회합니다.
-    Page<ChatMessage> findByWorkoutRoomOrderByTimestampAsc(WorkoutRoom workoutRoom, Pageable pageable);
+    // Page<ChatMessage> findByWorkoutRoomOrderByTimestampAsc(WorkoutRoom workoutRoom, Pageable pageable);
+
+    /* Slice를 사용해 다음 페이지 존재 여부를 효율적으로 확인 */
+
+    // 커서 ID를 기준으로 이전 메시지들을 Slice로 내림차순(최신순)으로 조회
+    Slice<ChatMessage> findByWorkoutRoomAndIdLessThanOrderByIdDesc(WorkoutRoom workoutRoom, Long id, Pageable pageable);
+
+    // 특정 채팅방의 가장 최신 메시지들을 조회
+    Slice<ChatMessage> findByWorkoutRoomOrderByIdDesc(WorkoutRoom workoutRoom, Pageable pageable);
+
+    // 마지막으로 읽은 메시지 이후의 모든 새 메시지를 조회
+    List<ChatMessage> findByWorkoutRoomAndIdGreaterThanOrderByIdAsc(WorkoutRoom workoutRoom, Long id);
+
+    // 특정 채팅방의 가장 최근 메시지 1개를 조회
+    ChatMessage findFirstByWorkoutRoomOrderByIdDesc(WorkoutRoom workoutRoom);
 }

--- a/src/main/java/com/behcm/domain/chat/service/ChatService.java
+++ b/src/main/java/com/behcm/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.behcm.domain.chat.service;
 
+import com.behcm.domain.chat.dto.ChatHistoryResponse;
 import com.behcm.domain.chat.dto.ChatMessageRequest;
 import com.behcm.domain.chat.dto.ChatMessageResponse;
 import com.behcm.domain.chat.entity.ChatMessage;
@@ -12,15 +13,17 @@ import com.behcm.domain.workout.repository.WorkoutRoomRepository;
 import com.behcm.global.exception.CustomException;
 import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -56,19 +59,43 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessageResponse> getChatHistory(Member member, Long roomId, int page, int size) {
+    public ChatHistoryResponse getChatHistory(Member member, Long roomId, Long cursorId, int size) {
         WorkoutRoomMember workoutRoomMember = workoutRoomMemberRepository.findByMember(member)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
         WorkoutRoom workoutRoom = workoutRoomMember.getWorkoutRoom();
         if (!roomId.equals(workoutRoom.getId())) {
             throw new IllegalArgumentException("roomId와 실제 운동방 id 불일치");
         }
-        Pageable pageable = PageRequest.of(page, size);
-        Page<ChatMessage> chatMessages = chatMessageRepository.findByWorkoutRoomOrderByTimestampAsc(workoutRoom, pageable);
 
-        return chatMessages.getContent().stream()
+        // 1. 초기 로드: cursorId가 null 일 때
+        if (cursorId == null) {
+            return getInitialMessages(workoutRoom, workoutRoomMember, size);
+        }
+
+        // 2. 이전 기록 스크롤 로드
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<ChatMessage> messageSlice = chatMessageRepository.findByWorkoutRoomAndIdLessThanOrderByIdDesc(workoutRoom, cursorId, pageable);
+        List<ChatMessageResponse> messages = messageSlice.getContent().stream()
                 .map(ChatMessageResponse::from)
+                .sorted(Comparator.comparing(ChatMessageResponse::getId))
                 .toList();
+
+        Long nextCursor = messages.isEmpty() ? null : messages.getFirst().getId();
+
+        return new ChatHistoryResponse(messages, nextCursor, messageSlice.hasNext());
+    }
+
+    public void updateLastReadMessage(Member member, Long roomId) {
+        WorkoutRoomMember workoutRoomMember = workoutRoomMemberRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
+        WorkoutRoom workoutRoom = workoutRoomMember.getWorkoutRoom();
+
+        // 현재 채팅방의 가장 최신 메시지를 찾음
+        ChatMessage latestMessage = chatMessageRepository.findFirstByWorkoutRoomOrderByIdDesc(workoutRoom);
+        if (latestMessage != null) {
+            workoutRoomMember.setLastReadMessage(latestMessage);
+            workoutRoomMemberRepository.save(workoutRoomMember);
+        }
     }
 
     public void markAsRead(Long roomId, Long messageId, Member member) {
@@ -85,5 +112,34 @@ public class ChatService {
         // 읽음 상태 업데이트 정보를 브로드캐스팅
         ChatMessageResponse response = ChatMessageResponse.from(chatMessage);
         messagingTemplate.convertAndSend("/topic/chat/room/" + roomId + "/read", response);
+    }
+
+    private ChatHistoryResponse getInitialMessages(WorkoutRoom workoutRoom, WorkoutRoomMember workoutRoomMember, int size) {
+        ChatMessage lastReadMessage = workoutRoomMember.getLastReadMessage();
+        long lastReadId = (lastReadMessage != null) ? lastReadMessage.getId() : 0L;
+
+
+        // 마지막으로 읽은 메시지 이후의 새로운 메시지들
+        // TODO: 새로운 메시지들이 많으면 한번에 조회하면 안됨.. 추후 개선
+        List<ChatMessage> newMessages = chatMessageRepository
+                .findByWorkoutRoomAndIdGreaterThanOrderByIdAsc(workoutRoom, lastReadId);
+
+        // 마지막으로 읽은 메시지를 포함한 이전 메시지들 (Pagination)
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<ChatMessage> oldMessageSlice = chatMessageRepository
+                .findByWorkoutRoomAndIdLessThanOrderByIdDesc(workoutRoom, lastReadId + 1, pageable);
+
+        List<ChatMessage> oldMessages = oldMessageSlice.getContent().stream()
+                .sorted(Comparator.comparing(ChatMessage::getId))
+                .toList();
+
+        // 두 리스트 합쳐서 반환
+        List<ChatMessageResponse> combinedMessages = Stream.concat(oldMessages.stream(), newMessages.stream())
+                .map(ChatMessageResponse::from)
+                .toList();
+
+        Long nextCursor = oldMessages.isEmpty() ? null : oldMessages.getFirst().getId();
+
+        return new ChatHistoryResponse(combinedMessages, nextCursor, oldMessageSlice.hasNext());
     }
 }

--- a/src/main/java/com/behcm/domain/workout/entity/WorkoutRoomMember.java
+++ b/src/main/java/com/behcm/domain/workout/entity/WorkoutRoomMember.java
@@ -1,11 +1,9 @@
 package com.behcm.domain.workout.entity;
 
+import com.behcm.domain.chat.entity.ChatMessage;
 import com.behcm.domain.member.entity.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -31,6 +29,11 @@ public class WorkoutRoomMember {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "workout_room_id", nullable = false)
     private WorkoutRoom workoutRoom;
+
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "last_read_chat_message_id")
+    private ChatMessage lastReadMessage; // 마지막으로 읽은 메시지 참조
 
     @Column(nullable = false)
     private Integer totalWorkouts = 0;


### PR DESCRIPTION
* 커서 기반 페이지네이션
* 마지막으로 조회한 메시지의 ID(cursorId)를 기준으로 이전 메시지를 불러오는 방식
* 스크롤을 위로 올리면, 마지막으로 읽은 메시지보다 이전의 대화 기록을 페이지네이션으로 추가 로딩