### PR TITLE
[Fix] 닉네임 변경 로직 수정

### DIFF
--- a/src/main/java/com/behcm/domain/member/service/MemberService.java
+++ b/src/main/java/com/behcm/domain/member/service/MemberService.java
@@ -13,6 +13,8 @@ import com.behcm.domain.workout.dto.WorkoutStatsResponse;
 import com.behcm.domain.workout.entity.WorkoutRecord;
 import com.behcm.domain.workout.repository.WorkoutLikeRepository;
 import com.behcm.domain.workout.repository.WorkoutRecordRepository;
+import com.behcm.global.exception.CustomException;
+import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
@@ -46,6 +48,9 @@ public class MemberService {
 
     @Transactional
     public MemberProfileResponse updateMemberProfile(Member member, UpdateMemberProfileRequest request) {
+        if (!member.getNickname().equals(request.getNickname()) && memberRepository.existsByNickname(request.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
         member.updateProfile(request.getNickname(), request.getBio(), request.getProfileUrl());
         Member savedMember = memberRepository.save(member);
 

--- a/src/main/java/com/behcm/global/exception/ErrorCode.java
+++ b/src/main/java/com/behcm/global/exception/ErrorCode.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // Auth
-    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
-    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
* 에러 메시지 수정
* 서비스 계층에서 중복 체크 추가하여 DB 계층에서 에러 안터뜨리도록 함 (DataIntegrityViolationException)
  - 닉네임 Unique 조건 위배 시 발생
* 변경하려는 닉네임이 현재 본인 닉네임과 동일할 경우 pass