### PR TITLE
[Fix] dockerhub에서 openjdk 이미지 지원 종료에 따른 jdk 이미지 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk
+FROM amazoncorretto:21-alpine-jdk
 
 ARG JAR_FILE=build/libs/*.jar
 


### PR DESCRIPTION
* https://hub.docker.com/_/openjdk 참고