### PR TITLE
[Fix] 알림 중복 수신, 헤드업 알림 미표시 이슈

### DIFF
--- a/src/main/java/com/behcm/domain/notification/service/FcmService.java
+++ b/src/main/java/com/behcm/domain/notification/service/FcmService.java
@@ -3,9 +3,7 @@ package com.behcm.domain.notification.service;
 import com.behcm.domain.member.entity.Member;
 import com.behcm.domain.notification.entity.FcmToken;
 import com.behcm.domain.notification.repository.FcmTokenRepository;
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -35,11 +33,17 @@ public class FcmService {
             try {
                 Message message = Message.builder()
                         .setToken(token)
-                        .setNotification(Notification.builder()
+/*                        .setNotification(Notification.builder()
                                 .setTitle(title)
                                 .setBody(body)
-                                .build())
+                                .build())*/
+                        .putData("title", title)
+                        .putData("body", body)
                         .putData("senderId", String.valueOf(senderId))
+                        .setAndroidConfig(AndroidConfig.builder()
+                                .setTtl(0)
+                                .setPriority(AndroidConfig.Priority.HIGH)
+                                .build())
                         .build();
                 FirebaseMessaging.getInstance().send(message);
                 log.debug("알림 발송 성공 (token: {})", token);


### PR DESCRIPTION
* 알림 중복
  - Service Worker onBackgroundMessage 수정: 백엔드에서 notification 필드를 포함해서 보내면 시스템이 1개 띄우고 + 서비스 워커가 1개 더 띄워서 알림 2개가 됨
  - notification 객체가 아니라 data 객체에서 값을 꺼내도록 수정

* 헤드업 알림 미표시
  - 안드로이드 8.0(Oreo) 이상부터는 알림 채널의 중요도(Priority) 설정이 필수