### PR TITLE
feat: 운동 인증 응답에 회원 누적 운동 일수(memberTotalWorkoutDays) 포함

### DIFF
--- a/src/main/java/com/behcm/domain/workout/dto/WorkoutResponse.java
+++ b/src/main/java/com/behcm/domain/workout/dto/WorkoutResponse.java
@@ -15,4 +15,5 @@ public class WorkoutResponse {
     private List<String> workoutTypes;
     private Integer duration;
     private List<String> imageUrls;
+    private Integer memberTotalWorkoutDays;
 }

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
@@ -63,9 +63,9 @@ public class WorkoutService {
             }
         }
         member.updateTotalWorkoutDays(member.getTotalWorkoutDays() + 1);
-        memberRepository.save(member);
+        Member savedMember = memberRepository.save(member);
 
-        return new WorkoutResponse(workoutDate, request.getWorkoutTypes(), request.getDuration(), imageUrls);
+        return new WorkoutResponse(workoutDate, request.getWorkoutTypes(), request.getDuration(), imageUrls, savedMember.getTotalWorkoutDays());
     }
 
     private boolean isThisWeek(LocalDate targetDate) {


### PR DESCRIPTION
Closes #60

## Description
- WorkoutResponse에 `memberTotalWorkoutDays` 필드 추가 (회원 누적 운동 일수)
- WorkoutService.authenticateWorkout()에서 저장된 회원의 totalWorkoutDays를 응답에 포함하도록 수정