### PR TITLE
운동방 상세 조회 성능 개선(N+1 제거)

### DIFF
--- a/src/main/java/com/behcm/domain/rest/repository/RestRepository.java
+++ b/src/main/java/com/behcm/domain/rest/repository/RestRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 @Repository
 public interface RestRepository extends JpaRepository<Rest, Long> {
     List<Rest> findAllByWorkoutRoomMember(WorkoutRoomMember workoutRoomMember);
+    List<Rest> findAllByWorkoutRoomMemberIn(List<WorkoutRoomMember> workoutRoomMembers);
 }

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRecordRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRecordRepository.java
@@ -74,4 +74,15 @@ public interface WorkoutRecordRepository extends JpaRepository<WorkoutRecord, Lo
 
     List<WorkoutRecord> findAllByWorkoutRoom(WorkoutRoom workoutRoom);
 
+    @Query(
+            """
+                select wr from WorkoutRecord wr
+                where 1=1
+                and wr.workoutRoom = :workoutRoom
+                and wr.member.id in :memberIds
+                order by wr.workoutDate desc
+            """
+    )
+    List<WorkoutRecord> findByWorkoutRoomAndMemberIn(@Param("workoutRoom") WorkoutRoom workoutRoom, @Param("memberIds") List<Long> memberIds);
+
 }

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomMemberRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomMemberRepository.java
@@ -4,6 +4,8 @@ import com.behcm.domain.member.entity.Member;
 import com.behcm.domain.workout.entity.WorkoutRoom;
 import com.behcm.domain.workout.entity.WorkoutRoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,6 +13,9 @@ import java.util.List;
 @Repository
 public interface WorkoutRoomMemberRepository extends JpaRepository<WorkoutRoomMember, Long> {
     List<WorkoutRoomMember> findByWorkoutRoomOrderByJoinedAt(WorkoutRoom workoutRoom);
+
+    @Query("SELECT wrm FROM WorkoutRoomMember wrm JOIN FETCH wrm.member WHERE wrm.workoutRoom = :workoutRoom ORDER BY wrm.joinedAt")
+    List<WorkoutRoomMember> findByWorkoutRoomOrderByJoinedAtFetchMember(@Param("workoutRoom") WorkoutRoom workoutRoom);
     boolean existsByMemberAndWorkoutRoom(Member member, WorkoutRoom workoutRoom);
     List<WorkoutRoomMember> findWorkoutRoomMembersByMember(Member member);
 }

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
@@ -19,8 +19,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.security.SecureRandom;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -85,24 +88,40 @@ public class WorkoutRoomService {
     public WorkoutRoomDetailResponse getJoinedWorkoutRoom(Long roomId, Member member) {
         WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND, "유저가 속한 운동방이 없습니다."));
-        List<WorkoutRoomMemberResponse> workoutRoomMembers = workoutRoomMemberRepository.findByWorkoutRoomOrderByJoinedAt(workoutRoom).stream()
+        List<WorkoutRoomMember> members = workoutRoomMemberRepository.findByWorkoutRoomOrderByJoinedAtFetchMember(workoutRoom);
+
+        final Map<Long, List<RestResponse>> restByWrmId;
+        final Map<Long, List<WorkoutRecordResponse>> recordsByMemberId;
+        if (!members.isEmpty()) {
+            List<Long> memberIds = members.stream()
+                    .map(wrm -> wrm.getMember().getId())
+                    .toList();
+            restByWrmId = restRepository.findAllByWorkoutRoomMemberIn(members).stream()
+                    .collect(Collectors.groupingBy(r -> r.getWorkoutRoomMember().getId()))
+                    .entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream().map(RestResponse::from).toList()));
+            recordsByMemberId = workoutRecordRepository.findByWorkoutRoomAndMemberIn(workoutRoom, memberIds).stream()
+                    .collect(Collectors.groupingBy(wr -> wr.getMember().getId()))
+                    .entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream().map(WorkoutRecordResponse::from).toList()));
+        } else {
+            restByWrmId = Collections.emptyMap();
+            recordsByMemberId = Collections.emptyMap();
+        }
+
+        List<WorkoutRoomMemberResponse> workoutRoomMembers = members.stream()
                 .map(workoutRoomMember -> {
-                    List<WorkoutRecordResponse> workoutRecords = workoutRecordRepository.findAllByMemberPerWorkoutDate(workoutRoomMember.getMember()).stream()
-                            .map(WorkoutRecordResponse::from)
-                            .toList();
-                    List<RestResponse> restInfoList = restRepository.findAllByWorkoutRoomMember(workoutRoomMember).stream()
-                            .map(RestResponse::from)
-                            .toList();
+                    List<WorkoutRecordResponse> workoutRecords = recordsByMemberId.getOrDefault(workoutRoomMember.getMember().getId(), List.of());
+                    List<RestResponse> restInfoList = restByWrmId.getOrDefault(workoutRoomMember.getId(), List.of());
                     return WorkoutRoomMemberResponse.of(workoutRoomMember, workoutRecords, restInfoList);
                 })
                 .toList();
+
         Optional<WorkoutRecord> currentMemberWorkoutRecordOpt = workoutRecordRepository.findByMemberAndWorkoutRoomAndWorkoutDate(member, workoutRoom, LocalDate.now());
-        WorkoutRecord currentMemberWorkoutRecord;
-        if (currentMemberWorkoutRecordOpt.isPresent()) {
-            currentMemberWorkoutRecord = currentMemberWorkoutRecordOpt.get();
-            return new WorkoutRoomDetailResponse(WorkoutRoomResponse.from(workoutRoom), workoutRoomMembers, WorkoutRecordResponse.from(currentMemberWorkoutRecord));
-        }
-        return new WorkoutRoomDetailResponse(WorkoutRoomResponse.from(workoutRoom), workoutRoomMembers, null);
+        return currentMemberWorkoutRecordOpt.map(workoutRecord -> new WorkoutRoomDetailResponse(
+                WorkoutRoomResponse.from(workoutRoom),
+                workoutRoomMembers,
+                WorkoutRecordResponse.from(workoutRecord))).orElseGet(() -> new WorkoutRoomDetailResponse(WorkoutRoomResponse.from(workoutRoom), workoutRoomMembers, null));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
Closes #69

## Description
- 운동방 상세 조회에서 멤버를 `JOIN FETCH`로 조회해 Lazy 로딩으로 인한 추가 쿼리를 줄였습니다.
- 휴식/운동기록을 방/멤버 기준으로 일괄 조회 후 `groupingBy`로 매핑하여 N+1 쿼리를 제거했습니다.
- 멤버가 없는 경우를 고려해 빈 컬렉션으로 안전 처리했습니다.