### PR TITLE
운동/패널티 도메인 성능 및 캐시 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/mdfiles/admin-search-indexes.md
+++ b/mdfiles/admin-search-indexes.md
@@ -1,0 +1,153 @@
+## 관리자 검색 인덱스/검색 컬럼 설계
+
+이 문서는 `MemberRepository.searchAdminMembers` 와 `WorkoutRoomRepository.searchAdminRooms` 에 대한
+MySQL 기준 인덱스 및 검색 컬럼 설계를 정리한 것입니다.
+
+---
+
+## 1. MemberRepository.searchAdminMembers
+
+대상 메서드:
+
+```java
+@Query("SELECT m FROM Member m " +
+        "WHERE (:role IS NULL OR m.role = :role) " +
+        "AND (:query IS NULL OR LOWER(m.nickname) LIKE LOWER(CONCAT('%', :query, '%')) " +
+        "OR LOWER(m.email) LIKE LOWER(CONCAT('%', :query, '%')))")
+Page<Member> searchAdminMembers(@Param("query") String query,
+                                @Param("role") MemberRole role,
+                                Pageable pageable);
+```
+
+### 1-1. 기본 인덱스 전략
+
+- **목표**: `role` 로 1차 필터링 후 `nickname` / `email` 로 LIKE 검색 시 불필요한 풀스캔을 줄입니다.
+- **전제**: MySQL 8.x, InnoDB 사용.
+
+권장 인덱스:
+
+```sql
+-- 역할 + 닉네임/이메일 복합 인덱스
+CREATE INDEX idx_member_role_nickname_email
+    ON member (role, nickname, email);
+```
+
+> 비고: `email`, `nickname` 에는 이미 유니크 인덱스가 존재하지만, `role` 과의 복합 인덱스를 두어
+> 관리자 검색(ROLE_ADMIN / ROLE_USER 등) 필터링 후 후속 LIKE 연산의 대상 row 수를 줄이는 것이 목표입니다.
+
+### 1-2. LOWER 기반 검색 최적화를 위한 함수 인덱스
+
+현재 JPQL 은 `LOWER(m.nickname)` / `LOWER(m.email)` 을 사용하므로,
+MySQL 8 의 함수 기반 인덱스를 사용하면 추가 컬럼 없이도 검색을 최적화할 수 있습니다.
+
+```sql
+-- LOWER(nickname), LOWER(email)을 사용하는 함수 기반 인덱스
+CREATE INDEX idx_member_role_lower_nickname_email
+    ON member (
+        role,
+        (LOWER(nickname)),
+        (LOWER(email))
+    );
+```
+
+> 운영 환경에서의 선택:
+>
+> - 대소문자 구분이 중요하지 않고, JPQL 에서 항상 `LOWER(...)` 를 사용하는 현재 패턴을 유지한다면
+>   위 함수 기반 인덱스를 채택합니다.
+> - 만약 추후 검색 컬럼을 별도로 두고자 한다면
+>   `lower_nickname`, `lower_email` 컬럼을 추가하고 트리거/애플리케이션 로직으로 동기화하는 전략도 가능합니다.
+
+---
+
+## 2. WorkoutRoomRepository.searchAdminRooms
+
+대상 메서드:
+
+```java
+@Query(
+        """
+                SELECT wr
+                FROM WorkoutRoom wr
+                JOIN wr.owner o
+                WHERE (:active IS NULL OR wr.isActive = :active)
+                AND (
+                    :query IS NULL
+                    OR LOWER(wr.name) LIKE LOWER(CONCAT('%', :query, '%'))
+                    OR LOWER(o.nickname) LIKE LOWER(CONCAT('%', :query, '%'))
+                )
+                """
+)
+Page<WorkoutRoom> searchAdminRooms(@Param("query") String query,
+                                   @Param("active") Boolean active,
+                                   Pageable pageable);
+```
+
+### 2-1. WorkoutRoom 기본 인덱스 전략
+
+목표:
+
+- `is_active` + 방 이름 기반 검색을 빠르게 수행.
+- 방 상태(active 여부) 필터와 이름 검색을 함께 사용하는 관리자 검색 시 풀스캔 최소화.
+
+권장 인덱스:
+
+```sql
+-- 활성 여부 + 방 이름 인덱스
+CREATE INDEX idx_workout_room_active_name
+    ON workout_room (is_active, name);
+```
+
+추가로, 방 소유자 기준으로 방을 조회하거나 상태와 함께 자주 필터링한다면 다음 인덱스도 고려할 수 있습니다.
+
+```sql
+-- 활성 여부 + owner_id 기준 인덱스
+CREATE INDEX idx_workout_room_active_owner
+    ON workout_room (is_active, owner_id);
+```
+
+### 2-2. LOWER 기반 방 이름 검색 최적화
+
+`LOWER(wr.name)` 을 사용하는 패턴을 그대로 유지하면서 인덱스를 활용하려면 함수 기반 인덱스를 사용할 수 있습니다.
+
+```sql
+-- LOWER(name)을 사용하는 함수 기반 인덱스
+CREATE INDEX idx_workout_room_active_lower_name
+    ON workout_room (
+        is_active,
+        (LOWER(name))
+    );
+```
+
+---
+
+## 3. Member.nickname / LOWER(o.nickname) 검색 보조 전략
+
+`WorkoutRoomRepository.searchAdminRooms` 에서는 방장 닉네임(`o.nickname`) 으로 검색합니다.
+
+- `Member.nickname` 은 `@Column(unique = true)` 로 이미 유니크 인덱스가 존재.
+- 다만 `LOWER(o.nickname)` 으로 검색하므로, 필요 시 함수 기반 인덱스를 추가할 수 있습니다.
+
+```sql
+-- LOWER(nickname)을 사용하는 함수 기반 인덱스
+CREATE INDEX idx_member_lower_nickname
+    ON member ((LOWER(nickname)));
+```
+
+---
+
+## 4. 적용 및 모니터링 가이드
+
+- **적용 방법**
+  - 운영 환경에서 사용 중인 마이그레이션 도구(Flyway/Liquibase 등)에
+    위 인덱스 DDL 을 순차적으로 추가합니다.
+- **검증 포인트**
+  - 인덱스 추가 전/후 `searchAdminMembers`, `searchAdminRooms` 호출 시
+    - 실행 계획(EXPLAIN)을 확인해 인덱스 사용 여부를 검증합니다.
+    - 쿼리 지연 시간 및 스캔 row 수 변화를 모니터링합니다.
+- **주의 사항**
+  - `%query%` 형태의 선행 와일드카드 LIKE 검색 특성상
+    인덱스 효과가 제한적일 수 있으므로, 필요 시
+    - 접두사 검색(`query%`)으로의 전환,
+    - 별도 검색 컬럼/검색 인덱스 도입,
+    - 전문검색(Full-text search) 도입 등을 장기적으로 검토할 수 있습니다.
+

--- a/mdfiles/performance-indexes-and-cache-monitoring.sql
+++ b/mdfiles/performance-indexes-and-cache-monitoring.sql
@@ -1,0 +1,73 @@
+-- Performance optimization indexes & cache monitoring guide
+-- 대상 DB: MariaDB / MySQL
+
+-- 1. WorkoutRecord 인덱스 (운동 인증, 벌금 배치, 통계 조회)
+-- 대상 쿼리 예시:
+--  - findAllByMemberPerWorkoutDate(memberId, workoutDate)
+--  - findByWorkoutRoomAndMemberIn(workoutRoomId, memberIds, between workoutDate)
+-- 기대 효과: 멤버/방/날짜 기반 조회 속도 개선, 벌금 계산 배치의 풀스캔 방지
+CREATE INDEX idx_workout_record_member_room_date
+    ON workout_record (member_id, workout_room_id, workout_date);
+
+CREATE INDEX idx_workout_record_member_date_created
+    ON workout_record (member_id, workout_date, created_at);
+
+
+-- 2. Rest 인덱스 (결석/휴식 집계, 벌금 계산)
+-- 대상 쿼리 예시:
+--  - findAllByWorkoutRoomMemberInAndStartDateBetween(members, startDate, endDate)
+-- 기대 효과: 방 멤버 리스트 + 기간 조건으로 조회 시 범위 스캔 최적화
+CREATE INDEX idx_rest_member_start_date
+    ON rest (workout_room_member_id, start_date);
+
+
+-- 3. Penalty 인덱스 (벌금 조회 및 집계)
+-- 대상 쿼리 예시:
+--  - findAllByWorkoutRoomIdAndMemberIdIn(roomId, memberIds)
+-- 기대 효과: 방/멤버 단위 벌금 조회 및 집계 속도 개선
+CREATE INDEX idx_penalty_room_member_created
+    ON penalty (workout_room_id, member_id, created_at);
+
+
+-- 4. Member / WorkoutRoom 인덱스 (관리자 검색)
+-- 대상 쿼리 예시:
+--  - searchAdminMembers(role, nickname, email LIKE ...)
+--  - searchAdminRooms(is_active, name LIKE ..., host_nickname)
+-- 기대 효과: ROLE + 닉네임/이메일, 방 활성 상태 + 이름 검색 성능 개선
+CREATE INDEX idx_member_role_nickname_email
+    ON member (role, nickname, email);
+
+CREATE INDEX idx_workout_room_active_name
+    ON workout_room (is_active, name);
+
+
+-- 5. 모니터링 & 검증 전략 (문서용, 실행 X)
+-- 5.1. SQL 로그 기반
+--  - application.yml 에 Hibernate SQL / slow query 로그를 활성화
+--  - 인덱스 적용 전후로 동일 시나리오(벌금 배치, 프로필 조회, 방 상세 조회)를 실행하여
+--    쿼리 횟수와 실행 시간을 비교
+--
+-- 5.2. Spring Actuator 기반
+--  - 의존성: spring-boot-starter-actuator
+--  - application.yml:
+--      management:
+--        endpoints:
+--          web:
+--            exposure:
+--              include: "health,info,metrics"
+--        endpoint:
+--          metrics:
+--            enabled: true
+--  - /actuator/metrics 를 통해 다음 항목 모니터링:
+--      - hikaricp.connections.*
+--      - http.server.requests (핵심 API 응답 시간 분포)
+--      - cache.gets / cache.misses (Caffeine 캐시 히트율)
+--
+-- 5.3. 기준 시나리오
+--  - 벌금 배치: PenaltyService 주간 처리 메서드 기준
+--  - 회원 프로필 조회: MemberService.getMemberProfile
+--  - 방 상세 조회: WorkoutRoomService.getJoinedWorkoutRoom
+--  - 주식 포트폴리오 / 현재가 조회: StockService.getStockPortfolio / getStockPrice
+--  위 시나리오에 대해, 인덱스/캐시 적용 전후의 평균 응답 시간과 쿼리 수를 비교하여
+--  성능 개선 효과를 검증한다.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "BE-HCM",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/main/java/com/behcm/domain/admin/member/service/AdminMemberService.java
+++ b/src/main/java/com/behcm/domain/admin/member/service/AdminMemberService.java
@@ -78,25 +78,18 @@ public class AdminMemberService {
         // 회원이 소유한 운동방 처리 (운동방 삭제)
         List<WorkoutRoom> ownedRooms = workoutRoomRepository.findByOwner(memberToDelete);
         for (WorkoutRoom room : ownedRooms) {
-            // 운동방의 모든 관련 데이터 삭제
+            // 운동방의 모든 관련 데이터 bulk delete 후 방 삭제
             deleteWorkoutRoomData(room);
             workoutRoomRepository.delete(room);
         }
 
-        // 회원이 참여한 운동방 멤버십 조회 및 관련 데이터 삭제
+        // 회원이 참여한 운동방 멤버십 및 관련 데이터 bulk delete
         List<WorkoutRoomMember> workoutRoomMembers = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(memberToDelete);
-        for (WorkoutRoomMember wrm : workoutRoomMembers) {
-            // Penalty 삭제
-            List<com.behcm.domain.penalty.entity.Penalty> penalties = penaltyRepository.findAllByWorkoutRoomId(wrm.getWorkoutRoom().getId());
-            penaltyRepository.deleteAll(penalties);
-
-            // Rest 삭제
-            List<com.behcm.domain.rest.entity.Rest> rests = restRepository.findAllByWorkoutRoomMember(wrm);
-            restRepository.deleteAll(rests);
+        if (!workoutRoomMembers.isEmpty()) {
+            restRepository.deleteAllByWorkoutRoomMemberIn(workoutRoomMembers);
+            penaltyRepository.deleteAllByWorkoutRoomMemberIn(workoutRoomMembers);
+            workoutRoomMemberRepository.deleteAll(workoutRoomMembers);
         }
-
-        // WorkoutRoomMember 삭제
-        workoutRoomMemberRepository.deleteAll(workoutRoomMembers);
 
         // WorkoutRecord 삭제
         workoutRecordRepository.deleteByMember(memberToDelete);
@@ -116,11 +109,11 @@ public class AdminMemberService {
     }
 
     private void deleteWorkoutRoomData(WorkoutRoom workoutRoom) {
-        // WorkoutRoomMember의 Rest 삭제
+        // 방에 속한 멤버 기반으로 Rest / Penalty bulk delete
         List<WorkoutRoomMember> members = workoutRoomMemberRepository.findByWorkoutRoomOrderByJoinedAt(workoutRoom);
-        for (WorkoutRoomMember wrm : members) {
-            List<com.behcm.domain.rest.entity.Rest> rests = restRepository.findAllByWorkoutRoomMember(wrm);
-            restRepository.deleteAll(rests);
+        if (!members.isEmpty()) {
+            restRepository.deleteAllByWorkoutRoomMemberIn(members);
+            penaltyRepository.deleteAllByWorkoutRoomMemberIn(members);
         }
 
         // WorkoutRecord 삭제
@@ -128,10 +121,6 @@ public class AdminMemberService {
 
         // ChatMessage 삭제
         chatMessageRepository.deleteByWorkoutRoom(workoutRoom);
-
-        // Penalty 삭제
-        List<com.behcm.domain.penalty.entity.Penalty> penalties = penaltyRepository.findAllByWorkoutRoomId(workoutRoom.getId());
-        penaltyRepository.deleteAll(penalties);
     }
 }
 

--- a/src/main/java/com/behcm/domain/member/service/MemberService.java
+++ b/src/main/java/com/behcm/domain/member/service/MemberService.java
@@ -12,6 +12,8 @@ import com.behcm.global.config.aws.S3Service;
 import com.behcm.global.exception.CustomException;
 import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -38,6 +40,7 @@ public class MemberService {
         return ProfileImageUploadResponse.of(profileUrl);
     }
 
+    @Cacheable(value = "memberProfile", key = "#member.id")
     public MemberProfileResponse getMemberProfile(Member member) {
         List<WorkoutRecord> workoutRecords = workoutRecordRepository.findAllByMemberPerWorkoutDate(member);
 
@@ -48,6 +51,7 @@ public class MemberService {
     }
 
     @Transactional
+    @CacheEvict(value = "memberProfile", key = "#member.id")
     public MemberProfileResponse updateMemberProfile(Member member, UpdateMemberProfileRequest request) {
         if (request.getNickname() != null
                 && !request.getNickname().equals(member.getNickname())

--- a/src/main/java/com/behcm/domain/penalty/repository/PenaltyRepository.java
+++ b/src/main/java/com/behcm/domain/penalty/repository/PenaltyRepository.java
@@ -1,6 +1,7 @@
 package com.behcm.domain.penalty.repository;
 
 import com.behcm.domain.penalty.entity.Penalty;
+import com.behcm.domain.workout.entity.WorkoutRoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +11,11 @@ import java.util.List;
 
 @Repository
 public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
+
     @Query("SELECT p FROM Penalty p WHERE p.workoutRoomMember.workoutRoom.id = :roomId")
     List<Penalty> findAllByWorkoutRoomId(@Param("roomId") Long roomId);
+
+    void deleteAllByWorkoutRoomMemberIn(List<WorkoutRoomMember> workoutRoomMembers);
+
+    void deleteAllByWorkoutRoomMember(WorkoutRoomMember workoutRoomMember);
 }

--- a/src/main/java/com/behcm/domain/penalty/service/PenaltyService.java
+++ b/src/main/java/com/behcm/domain/penalty/service/PenaltyService.java
@@ -20,11 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
-import java.util.UUID;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -111,15 +109,30 @@ public class PenaltyService {
         log.info("Processing penalties for workout room: {} (ID: {})", workoutRoom.getName(), workoutRoom.getId());
 
         List<WorkoutRoomMember> members = workoutRoom.getWorkoutRoomMembers();
+        if (members.isEmpty()) {
+            log.info("No members in workout room {} (ID: {}), skipping penalty calculation", workoutRoom.getName(), workoutRoom.getId());
+            return;
+        }
+
+        Map<Long, Integer> actualWorkoutsByMemberId = workoutRecordRepository
+                .countByWorkoutRoomAndWorkoutDateBetweenGroupByMember(workoutRoom, weekStart, weekEnd)
+                .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> ((Long) row[1]).intValue()
+                ));
+
+        List<Rest> restPeriods = restRepository.findAllByWorkoutRoomMemberIn(members);
+        Map<Long, List<Rest>> restByWorkoutRoomMemberId = restPeriods.stream()
+                .collect(Collectors.groupingBy(rest -> rest.getWorkoutRoomMember().getId()));
 
         for (WorkoutRoomMember member : members) {
-            if (isMemberOnBreak(member, weekStart, weekEnd)) {
+            if (isMemberOnBreak(member, weekStart, weekEnd, restByWorkoutRoomMemberId)) {
                 log.debug("Skipping penalty calculation for member {} - on break", member.getNickname());
                 continue;
             }
 
-            int actualWorkouts = (int) workoutRecordRepository.countByMemberAndWorkoutRoomAndWorkoutDateBetween(
-                    member.getMember(), workoutRoom, weekStart, weekEnd);
+            int actualWorkouts = actualWorkoutsByMemberId.getOrDefault(member.getMember().getId(), 0);
 
             int requiredWorkouts = workoutRoom.getMinWeeklyWorkouts();
 
@@ -149,8 +162,9 @@ public class PenaltyService {
         }
     }
 
-    private boolean isMemberOnBreak(WorkoutRoomMember member, LocalDate weekStart, LocalDate weekEnd) {
-        List<Rest> restPeriods = restRepository.findAllByWorkoutRoomMember(member);
+    private boolean isMemberOnBreak(WorkoutRoomMember member, LocalDate weekStart, LocalDate weekEnd,
+                                    Map<Long, List<Rest>> restByWorkoutRoomMemberId) {
+        List<Rest> restPeriods = restByWorkoutRoomMemberId.getOrDefault(member.getId(), List.of());
 
         return restPeriods.stream().anyMatch(rest ->
                 !(rest.getEndDate().isBefore(weekStart) || rest.getStartDate().isAfter(weekEnd))

--- a/src/main/java/com/behcm/domain/rest/repository/RestRepository.java
+++ b/src/main/java/com/behcm/domain/rest/repository/RestRepository.java
@@ -10,5 +10,10 @@ import java.util.List;
 @Repository
 public interface RestRepository extends JpaRepository<Rest, Long> {
     List<Rest> findAllByWorkoutRoomMember(WorkoutRoomMember workoutRoomMember);
+
     List<Rest> findAllByWorkoutRoomMemberIn(List<WorkoutRoomMember> workoutRoomMembers);
+
+    void deleteAllByWorkoutRoomMemberIn(List<WorkoutRoomMember> workoutRoomMembers);
+
+    void deleteAllByWorkoutRoomMember(WorkoutRoomMember workoutRoomMember);
 }

--- a/src/main/java/com/behcm/domain/workout/entity/WorkoutRecord.java
+++ b/src/main/java/com/behcm/domain/workout/entity/WorkoutRecord.java
@@ -15,6 +15,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(
+        name = "workout_record",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_workout_record_member_room_date",
+                        columnNames = {"member_id", "workout_room_id", "workout_date"}
+                )
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRecordRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRecordRepository.java
@@ -54,6 +54,21 @@ public interface WorkoutRecordRepository extends JpaRepository<WorkoutRecord, Lo
 
     @Query(
             """
+                select wr.member.id, count(wr)
+                from WorkoutRecord wr
+                where wr.workoutRoom = :workoutRoom
+                and wr.workoutDate >= :startDate and wr.workoutDate <= :endDate
+                group by wr.member.id
+            """
+    )
+    List<Object[]> countByWorkoutRoomAndWorkoutDateBetweenGroupByMember(
+            @Param("workoutRoom") WorkoutRoom workoutRoom,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+    @Query(
+            """
                 select wr
                 from WorkoutRecord wr
                 where wr.member = :member
@@ -84,5 +99,20 @@ public interface WorkoutRecordRepository extends JpaRepository<WorkoutRecord, Lo
             """
     )
     List<WorkoutRecord> findByWorkoutRoomAndMemberIn(@Param("workoutRoom") WorkoutRoom workoutRoom, @Param("memberIds") List<Long> memberIds);
+
+    @Query(
+            """
+                select wr
+                from WorkoutRecord wr
+                where wr.member = :member
+                and wr.workoutDate = :workoutDate
+                and wr.workoutRoom in :workoutRooms
+            """
+    )
+    List<WorkoutRecord> findByMemberAndWorkoutDateAndWorkoutRoomIn(
+            @Param("member") Member member,
+            @Param("workoutDate") LocalDate workoutDate,
+            @Param("workoutRooms") List<WorkoutRoom> workoutRooms
+    );
 
 }

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomMemberRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomMemberRepository.java
@@ -4,6 +4,7 @@ import com.behcm.domain.member.entity.Member;
 import com.behcm.domain.workout.entity.WorkoutRoom;
 import com.behcm.domain.workout.entity.WorkoutRoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -18,4 +19,8 @@ public interface WorkoutRoomMemberRepository extends JpaRepository<WorkoutRoomMe
     List<WorkoutRoomMember> findByWorkoutRoomOrderByJoinedAtFetchMember(@Param("workoutRoom") WorkoutRoom workoutRoom);
     boolean existsByMemberAndWorkoutRoom(Member member, WorkoutRoom workoutRoom);
     List<WorkoutRoomMember> findWorkoutRoomMembersByMember(Member member);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update WorkoutRoomMember wrm set wrm.weeklyWorkouts = 0 where wrm.weeklyWorkouts <> 0")
+    void resetWeeklyWorkouts();
 }

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
@@ -14,6 +14,7 @@ import com.behcm.global.exception.CustomException;
 import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -85,6 +86,7 @@ public class WorkoutRoomService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "workoutRoomDetail", key = "#roomId + '-' + #member.id")
     public WorkoutRoomDetailResponse getJoinedWorkoutRoom(Long roomId, Member member) {
         WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND, "유저가 속한 운동방이 없습니다."));

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutSchedulingService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutSchedulingService.java
@@ -1,7 +1,6 @@
 package com.behcm.domain.workout.service;
 
 import com.behcm.domain.penalty.service.PenaltyService;
-import com.behcm.domain.workout.entity.WorkoutRoomMember;
 import com.behcm.domain.workout.repository.WorkoutRoomMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +33,7 @@ public class WorkoutSchedulingService {
     private void resetWeeklyWorkouts() {
         log.info("Starting weekly workout reset");
 
-        workoutRoomMemberRepository.findAll().forEach(WorkoutRoomMember::resetWeeklyWorkouts);
+        workoutRoomMemberRepository.resetWeeklyWorkouts();
 
         log.info("Weekly workout reset completed");
     }

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
@@ -13,6 +13,8 @@ import com.behcm.global.config.aws.S3Service;
 import com.behcm.global.exception.CustomException;
 import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,21 +33,33 @@ public class WorkoutService {
     private final WorkoutRoomMemberRepository workoutRoomMemberRepository;
     private final MemberRepository memberRepository;
     private final S3Service s3Service;
+    private final CacheManager cacheManager;
 
+    @CacheEvict(value = "workoutRoomDetail", allEntries = true)
     public WorkoutResponse authenticateWorkout(Member member, WorkoutRequest request) {
         LocalDate workoutDate = LocalDate.parse(request.getWorkoutDate(), DateTimeFormatter.ISO_LOCAL_DATE);
         List<WorkoutRoomMember> wrms = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member);
         if (wrms.isEmpty()) {
             throw new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND);
         }
+
+        // 멤버가 참여 중인 모든 방에 대해, 해당 날짜에 이미 운동 인증이 존재하는지 한 번의 쿼리로 검사
+        List<WorkoutRoom> workoutRooms = wrms.stream()
+                .map(WorkoutRoomMember::getWorkoutRoom)
+                .toList();
+        List<WorkoutRecord> existingRecords = workoutRecordRepository.findByMemberAndWorkoutDateAndWorkoutRoomIn(
+                member,
+                workoutDate,
+                workoutRooms
+        );
+        if (!existingRecords.isEmpty()) {
+            throw new CustomException(ErrorCode.WORKOUT_ALREADY_AUTHENTICATED);
+        }
+
         // 여러 이미지 S3에 업로드
         List<String> imageUrls = s3Service.uploadImages(request.getImages());
         for (WorkoutRoomMember wrm : wrms) {
             WorkoutRoom workoutRoom = wrm.getWorkoutRoom();
-            // 중복 운동 인증 체크
-            if (workoutRecordRepository.existsByMemberAndWorkoutRoomAndWorkoutDate(member, workoutRoom, workoutDate)) {
-                throw new CustomException(ErrorCode.WORKOUT_ALREADY_AUTHENTICATED);
-            }
             // 운동 기록 저장
             WorkoutRecord workoutRecord = WorkoutRecord.builder()
                     .member(member)

--- a/src/main/java/com/behcm/global/config/CacheConfig.java
+++ b/src/main/java/com/behcm/global/config/CacheConfig.java
@@ -1,0 +1,46 @@
+package com.behcm.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+
+        CaffeineCache memberProfileCache = new CaffeineCache(
+                "memberProfile",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(10, TimeUnit.MINUTES)
+                        .maximumSize(10_000)
+                        .build()
+        );
+
+        CaffeineCache workoutRoomDetailCache = new CaffeineCache(
+                "workoutRoomDetail",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(1, TimeUnit.MINUTES)
+                        .maximumSize(5_000)
+                        .build()
+        );
+
+        cacheManager.setCaches(List.of(
+                memberProfileCache,
+                workoutRoomDetailCache
+        ));
+
+        return cacheManager;
+    }
+}
+


### PR DESCRIPTION
Closes #72

## Description
운동 기록, 운동방, 패널티, 휴식 관련 서비스 전반의 조회/처리 성능을 개선하고, Spring Cache 설정 및 DB 인덱스/모니터링 전략을 추가했습니다.

- Admin/일반 멤버 서비스 조회 로직 리팩터링 및 성능 고려한 메서드/쿼리 사용
- 패널티/휴식 도메인 조회 쿼리 및 서비스 로직 보강
- 운동 기록/운동방 관련 엔티티 및 레포지토리 메서드 확장
- `CacheConfig`를 통한 캐시 설정 추가 및 활용 기반 마련
- DB 인덱스 및 캐시/성능 모니터링 전략을 문서로 정리

이 PR은 위 변경 사항들을 한꺼번에 리뷰하고 `main` 브랜치에 병합하기 위한 것입니다.