### PR TITLE
회원/운동방 캐시 임시 비활성화 및 dev DDL 전략 수정

### DIFF
--- a/src/main/java/com/behcm/domain/member/service/MemberService.java
+++ b/src/main/java/com/behcm/domain/member/service/MemberService.java
@@ -40,7 +40,7 @@ public class MemberService {
         return ProfileImageUploadResponse.of(profileUrl);
     }
 
-    @Cacheable(value = "memberProfile", key = "#member.id")
+//    @Cacheable(value = "memberProfile", key = "#member.id")
     public MemberProfileResponse getMemberProfile(Member member) {
         List<WorkoutRecord> workoutRecords = workoutRecordRepository.findAllByMemberPerWorkoutDate(member);
 
@@ -51,7 +51,7 @@ public class MemberService {
     }
 
     @Transactional
-    @CacheEvict(value = "memberProfile", key = "#member.id")
+//    @CacheEvict(value = "memberProfile", key = "#member.id")
     public MemberProfileResponse updateMemberProfile(Member member, UpdateMemberProfileRequest request) {
         if (request.getNickname() != null
                 && !request.getNickname().equals(member.getNickname())

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
@@ -86,7 +86,7 @@ public class WorkoutRoomService {
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(value = "workoutRoomDetail", key = "#roomId + '-' + #member.id")
+//    @Cacheable(value = "workoutRoomDetail", key = "#roomId + '-' + #member.id")
     public WorkoutRoomDetailResponse getJoinedWorkoutRoom(Long roomId, Member member) {
         WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND, "유저가 속한 운동방이 없습니다."));

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,7 +16,7 @@ spring:
         format_sql: false
         highlight_sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: false
   data:
     redis:


### PR DESCRIPTION
Closes #74

## Description
회원 프로필 및 운동방 상세 조회 캐시를 일시적으로 비활성화하고, 개발 환경(`application-dev.yml`)의 JPA DDL 전략을 `create`에서 `update`로 변경했습니다.

- `MemberService`
  - `getMemberProfile(Member member)`의 `@Cacheable("memberProfile")` 주석 처리
  - `updateMemberProfile(...)`의 `@CacheEvict("memberProfile")` 주석 처리
- `WorkoutRoomService`
  - `getJoinedWorkoutRoom(Long roomId, Member member)`의 `@Cacheable("workoutRoomDetail")` 주석 처리
- `application-dev.yml`
  - `spring.jpa.hibernate.ddl-auto: create` → `update` 변경

개발 환경에서 캐시 동작 및 DB 스키마 변경을 보다 안정적으로 검증하기 위한 임시 조치이며, 추후 캐시 전략 보완 후 다시 활성화할 예정입니다.