### PR TITLE
채팅 이미지 업로드 API 및 WebSocket 연동 구현

### DIFF
--- a/mdfiles/backend-chat-image-upload.md
+++ b/mdfiles/backend-chat-image-upload.md
@@ -1,0 +1,154 @@
+# 채팅 이미지 업로드 — 백엔드 작업 사항
+
+프론트엔드 ChatRoom 이미지 업로드 기능에 맞추어 백엔드에서 구현해야 할 API 및 WebSocket 스펙을 정리한 문서입니다.
+
+---
+
+## 1. REST API: 채팅 이미지 업로드
+
+### 1.1 엔드포인트
+
+| 항목   | 내용                                       |
+| ------ | ------------------------------------------ |
+| Method | `POST`                                     |
+| Path   | `/api/chat/rooms/{roomId}/images`          |
+| 인증   | `Authorization: Bearer {accessToken}` 필요 |
+
+### 1.2 요청
+
+- **Content-Type**: `multipart/form-data`
+- **Body**: form 필드명 `file` 로 이미지 파일 1개 전송
+
+**프론트엔드 전송 예시**
+
+```ts
+const formData = new FormData();
+formData.append("file", file); // File 객체 1개
+await api.uploadChatImage(roomId, formData);
+```
+
+### 1.3 요청 검증 (권장)
+
+프론트에서 아래와 같이 제한하고 있으나, 백엔드에서도 동일하게 검증하는 것을 권장합니다.
+
+| 검증 항목      | 값                                      |
+| -------------- | --------------------------------------- |
+| 허용 MIME 타입 | `image/jpeg`, `image/png`, `image/webp` |
+| 최대 파일 크기 | 5MB (5 × 1024 × 1024 bytes)             |
+
+- 검증 실패 시: 400 등 적절한 HTTP 상태 코드와 `message` 등 에러 메시지 반환
+- 프론트는 `error.response?.data?.message` 또는 `error.message`를 사용자에게 표시합니다.
+
+### 1.4 응답
+
+**성공 시 (예: 200)**
+
+- 응답 body에 **이미지 URL**을 담아 반환해야 합니다.
+- 프론트는 `response.data.data` 또는 `response.data`를 사용하므로, 아래 두 형태 모두 지원 가능합니다.
+
+**형식 A (권장)**
+
+```json
+{
+  "data": {
+    "imageUrl": "https://your-cdn-or-storage.example/chat/rooms/1/abc123.jpg"
+  }
+}
+```
+
+**형식 B**
+
+```json
+{
+  "imageUrl": "https://your-cdn-or-storage.example/chat/rooms/1/abc123.jpg"
+}
+```
+
+- **필드명**: 반드시 `imageUrl` (카멜케이스).
+- **값**: 클라이언트가 `<img src="">` 에 그대로 넣을 수 있는 **절대 URL** (공개 접근 가능한 URL).
+
+### 1.5 백엔드 구현 시 할 일
+
+- [ ] `POST /api/chat/rooms/{roomId}/images` 컨트롤러/라우트 추가
+- [ ] `roomId`에 해당하는 채팅방 존재 여부 및 요청자가 해당 방 멤버인지 검증
+- [ ] `multipart/form-data`에서 `file` 필드 수신 및 파일 타입/크기 검증 (jpeg, png, webp, 5MB 이하)
+- [ ] 파일을 저장소(S3, 로컬 스토리지 등)에 업로드 후 **공개 URL** 생성
+- [ ] 응답 body에 `imageUrl` 포함하여 반환 (위 1.4 형식 A 또는 B)
+
+---
+
+## 2. WebSocket(STOMP): 이미지 메시지 수신/저장/브로드캐스트
+
+이미지 업로드 API로 `imageUrl`을 받은 뒤, 프론트는 **기존 채팅 메시지 전송 경로**로 이미지 메시지를 보냅니다.
+
+### 2.1 전송 경로 및 페이로드
+
+| 항목        | 내용                                                                          |
+| ----------- | ----------------------------------------------------------------------------- |
+| Destination | `/app/chat/room/{roomId}/send`                                                |
+| Body (JSON) | `{ "type": "IMAGE", "content": "", "imageUrl": "{업로드 API에서 받은 URL}" }` |
+
+**프론트엔드 전송 예시**
+
+```ts
+clientRef.current.publish({
+  destination: `/app/chat/room/${roomId}/send`,
+  body: JSON.stringify({
+    type: "IMAGE",
+    content: "",
+    imageUrl: imageUrl,
+  }),
+  headers: {
+    Authorization: `Bearer ${accessToken}`,
+    "content-type": "application/json",
+  },
+});
+```
+
+### 2.2 백엔드 처리 요구사항
+
+- 기존 텍스트 메시지(`type: "TEXT"`)와 동일한 엔드포인트에서 처리해도 됩니다.
+- **type**이 `"IMAGE"`일 때:
+  - **content**: 빈 문자열(`""`)로 수신됨.
+  - **imageUrl**: 필수. 업로드 API에서 발급한 이미지 URL.
+- 해당 메시지를 DB 등에 저장할 때 `type`, `imageUrl`(및 필요 시 `content`)를 저장하고, 동일 채팅방 구독자에게 그대로 브로드캐스트하면 됩니다.
+
+### 2.3 채팅 기록 API 응답 형식
+
+이미지 메시지도 **기존 채팅 기록 API** (`GET /api/chat/rooms/{roomId}/messages`) 응답에 포함되어야 합니다.
+
+**메시지 객체 예시 (IMAGE)**
+
+```json
+{
+  "id": "msg-uuid-or-id",
+  "sender": "닉네임",
+  "content": "",
+  "timestamp": "2025-03-12T10:00:00.000Z",
+  "type": "IMAGE",
+  "imageUrl": "https://your-cdn.example/chat/rooms/1/abc123.jpg"
+}
+```
+
+- `type`: `"TEXT"` | `"IMAGE"`
+- 이미지 메시지일 때는 `imageUrl` 필드 필수, `content`는 빈 문자열 가능.
+
+### 2.4 백엔드 구현 시 할 일
+
+- [ ] `/app/chat/room/{roomId}/send` 에서 payload의 `type`이 `"IMAGE"`인 경우 처리
+- [ ] `imageUrl` 검증(필수, 비어 있지 않은 URL 등) 후 DB/저장소에 메시지 저장
+- [ ] 동일 방 구독자에게 `type`, `content`, `imageUrl` 포함한 메시지 브로드캐스트
+- [ ] `GET /api/chat/rooms/{roomId}/messages` 응답에 이미지 메시지도 `type`, `imageUrl` 포함하여 반환
+
+---
+
+## 3. 정리
+
+| 구분      | 항목               | 요약                                                                      |
+| --------- | ------------------ | ------------------------------------------------------------------------- |
+| REST      | 채팅 이미지 업로드 | `POST /api/chat/rooms/{roomId}/images`, multipart `file`, 응답 `imageUrl` |
+| REST      | 검증               | 이미지 타입(jpeg/png/webp), 크기(5MB 이하), 방 존재·멤버 여부             |
+| WebSocket | 이미지 메시지      | 기존 send 경로에서 `type: "IMAGE"`, `imageUrl` 수신·저장·브로드캐스트     |
+| API       | 채팅 기록          | 이미지 메시지도 `type`, `imageUrl` 포함하여 반환                          |
+
+위 스펙에 맞추어 구현하면 프론트엔드와 연동됩니다.

--- a/src/main/java/com/behcm/domain/admin/member/service/AdminMemberService.java
+++ b/src/main/java/com/behcm/domain/admin/member/service/AdminMemberService.java
@@ -84,7 +84,7 @@ public class AdminMemberService {
         }
 
         // 회원이 참여한 운동방 멤버십 및 관련 데이터 bulk delete
-        List<WorkoutRoomMember> workoutRoomMembers = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(memberToDelete);
+        List<WorkoutRoomMember> workoutRoomMembers = workoutRoomMemberRepository.findByMember(memberToDelete);
         if (!workoutRoomMembers.isEmpty()) {
             restRepository.deleteAllByWorkoutRoomMemberIn(workoutRoomMembers);
             penaltyRepository.deleteAllByWorkoutRoomMemberIn(workoutRoomMembers);

--- a/src/main/java/com/behcm/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/behcm/domain/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.behcm.domain.chat.controller;
 
 import com.behcm.domain.chat.dto.ChatHistoryResponse;
+import com.behcm.domain.chat.dto.ChatImageUploadResponse;
 import com.behcm.domain.chat.dto.ChatMessageRequest;
 import com.behcm.domain.chat.service.ChatService;
 import com.behcm.domain.member.entity.Member;
@@ -15,6 +16,7 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -44,6 +46,17 @@ public class ChatController {
             @AuthenticationPrincipal Member member
     ) {
         chatService.markAsRead(roomId, messageId, member);
+    }
+
+    // 채팅 이미지 업로드
+    @PostMapping("/api/chat/rooms/{roomId}/images")
+    public ResponseEntity<ApiResponse<ChatImageUploadResponse>> uploadChatImage(
+            @PathVariable Long roomId,
+            @RequestParam("file") MultipartFile file,
+            @AuthenticationPrincipal Member member
+    ) {
+        ChatImageUploadResponse response = chatService.uploadChatImage(member, roomId, file);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 채팅방의 이전 대화 기록을 가져오는 API

--- a/src/main/java/com/behcm/domain/chat/dto/ChatImageUploadResponse.java
+++ b/src/main/java/com/behcm/domain/chat/dto/ChatImageUploadResponse.java
@@ -1,0 +1,17 @@
+package com.behcm.domain.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatImageUploadResponse {
+
+    private String imageUrl;
+
+    public static ChatImageUploadResponse of(String imageUrl) {
+        return ChatImageUploadResponse.builder()
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/behcm/domain/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/behcm/domain/chat/dto/ChatMessageRequest.java
@@ -7,4 +7,5 @@ import lombok.Data;
 public class ChatMessageRequest {
     private MessageType type;
     private String content;
+    private String imageUrl;
 }

--- a/src/main/java/com/behcm/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/behcm/domain/chat/entity/ChatMessage.java
@@ -11,8 +11,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -32,11 +30,6 @@ public class ChatMessage {
     private MessageType messageType;
 
     private String imageUrl;
-
-/*    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "chat_message_read_by", joinColumns = @JoinColumn(name = "chat_message_id"))
-    @Column(name = "member_nickname")
-    private Set<String> readBy = new HashSet<>();*/
 
     @CreatedDate
     @Column(updatable = false)
@@ -58,8 +51,4 @@ public class ChatMessage {
         this.workoutRoom = workoutRoom;
         this.sender = sender;
     }
-
-//    public void addReadBy(String nickname) {
-//        this.readBy.add(nickname);
-//    }
 }

--- a/src/main/java/com/behcm/domain/chat/service/ChatService.java
+++ b/src/main/java/com/behcm/domain/chat/service/ChatService.java
@@ -1,25 +1,29 @@
 package com.behcm.domain.chat.service;
 
 import com.behcm.domain.chat.dto.ChatHistoryResponse;
+import com.behcm.domain.chat.dto.ChatImageUploadResponse;
 import com.behcm.domain.chat.dto.ChatMessageRequest;
 import com.behcm.domain.chat.dto.ChatMessageResponse;
 import com.behcm.domain.chat.entity.ChatMessage;
+import com.behcm.domain.chat.entity.MessageType;
 import com.behcm.domain.chat.repository.ChatMessageRepository;
 import com.behcm.domain.member.entity.Member;
 import com.behcm.domain.workout.entity.WorkoutRoom;
 import com.behcm.domain.workout.entity.WorkoutRoomMember;
 import com.behcm.domain.workout.repository.WorkoutRoomMemberRepository;
 import com.behcm.domain.workout.repository.WorkoutRoomRepository;
+import com.behcm.global.config.aws.S3Service;
 import com.behcm.global.exception.CustomException;
 import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.util.StringUtils;
 
 import java.util.Comparator;
 import java.util.List;
@@ -32,19 +36,41 @@ public class ChatService {
 
     private final ChatMessageRepository chatMessageRepository;
     private final WorkoutRoomMemberRepository workoutRoomMemberRepository;
+    private final WorkoutRoomRepository workoutRoomRepository;
+    private final S3Service s3Service;
     private final SimpMessagingTemplate messagingTemplate;
 
-    public void sendMessage(Long roomId, Member sender, ChatMessageRequest request) {
-        WorkoutRoomMember wrm = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(sender).stream()
-                .filter(workoutRoomMember -> workoutRoomMember.getWorkoutRoom().getId().equals(roomId))
-                .findFirst()
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
+    public ChatImageUploadResponse uploadChatImage(Member member, Long roomId, MultipartFile file) {
+        WorkoutRoom workoutRoom = workoutRoomRepository.findByIdAndIsActiveTrue(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
+        if (!workoutRoomMemberRepository.existsByMemberAndWorkoutRoom(member, workoutRoom)) {
+            throw new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER);
+        }
+        String imageUrl = s3Service.uploadChatImage(file, workoutRoom.getId());
+        return ChatImageUploadResponse.of(imageUrl);
+    }
 
+    public void sendMessage(Long roomId, Member sender, ChatMessageRequest request) {
+        WorkoutRoom workoutRoom = workoutRoomRepository.findByIdAndIsActiveTrue(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
+        if (!workoutRoomMemberRepository.existsByMemberAndWorkoutRoom(sender, workoutRoom)) {
+            throw new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER);
+        }
+        if (request.getType() == MessageType.IMAGE) {
+            if (!StringUtils.hasText(request.getImageUrl())) {
+                throw new CustomException(ErrorCode.INVALID_INPUT, "이미지 URL이 필요합니다.");
+            }
+        }
+
+        String imageUrl = (request.getType() == MessageType.IMAGE)
+                ? request.getImageUrl().trim()
+                : null;
         ChatMessage chatMessage = ChatMessage.builder()
                 .sender(sender)
-                .workoutRoom(wrm.getWorkoutRoom())
-                .content(request.getContent())
+                .workoutRoom(workoutRoom)
+                .content(request.getContent() != null ? request.getContent() : "")
                 .messageType(request.getType())
+                .imageUrl(imageUrl)
                 .build();
 
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
@@ -55,9 +81,9 @@ public class ChatService {
 
     @Transactional(readOnly = true)
     public ChatHistoryResponse getChatHistory(Member member, Long roomId, Long cursorId, int size) {
-        WorkoutRoomMember wrm = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member).stream()
-                .filter(workoutRoomMember -> workoutRoomMember.getWorkoutRoom().getId().equals(roomId))
-                .findFirst()
+        WorkoutRoom workoutRoom = workoutRoomRepository.findByIdAndIsActiveTrue(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
+        WorkoutRoomMember wrm = workoutRoomMemberRepository.findByWorkoutRoomAndMember(workoutRoom, member)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
 
         // 1. 초기 로드: cursorId가 null 일 때
@@ -79,9 +105,9 @@ public class ChatService {
     }
 
     public void updateLastReadMessage(Member member, Long roomId) {
-        WorkoutRoomMember wrm = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member).stream()
-                .filter(workoutRoomMember -> workoutRoomMember.getWorkoutRoom().getId().equals(roomId))
-                .findFirst()
+        WorkoutRoom workoutRoom = workoutRoomRepository.findByIdAndIsActiveTrue(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
+        WorkoutRoomMember wrm = workoutRoomMemberRepository.findByWorkoutRoomAndMember(workoutRoom, member)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
 
         // 현재 채팅방의 가장 최신 메시지를 찾음
@@ -93,9 +119,9 @@ public class ChatService {
     }
 
     public void markAsRead(Long roomId, Long messageId, Member member) {
-        WorkoutRoomMember wrm = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member).stream()
-                .filter(workoutRoomMember -> workoutRoomMember.getWorkoutRoom().getId().equals(roomId))
-                .findFirst()
+        WorkoutRoom workoutRoom = workoutRoomRepository.findByIdAndIsActiveTrue(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
+        WorkoutRoomMember wrm = workoutRoomMemberRepository.findByWorkoutRoomAndMember(workoutRoom, member)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
         ChatMessage chatMessage = chatMessageRepository.findById(messageId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));

--- a/src/main/java/com/behcm/domain/rest/service/RestService.java
+++ b/src/main/java/com/behcm/domain/rest/service/RestService.java
@@ -25,7 +25,7 @@ public class RestService {
     private final WorkoutRoomMemberRepository workoutRoomMemberRepository;
 
     public void registerRestDay(Member member, RestRequest request) {
-        List<WorkoutRoomMember> wrms = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member);
+        List<WorkoutRoomMember> wrms = workoutRoomMemberRepository.findByMember(member);
         if (wrms.isEmpty()) {
             throw new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND);
         }

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomMemberRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomMemberRepository.java
@@ -10,15 +10,17 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface WorkoutRoomMemberRepository extends JpaRepository<WorkoutRoomMember, Long> {
+    boolean existsByMemberAndWorkoutRoom(Member member, WorkoutRoom workoutRoom);
+    Optional<WorkoutRoomMember> findByWorkoutRoomAndMember(WorkoutRoom workoutRoom, Member member);
     List<WorkoutRoomMember> findByWorkoutRoomOrderByJoinedAt(WorkoutRoom workoutRoom);
+    List<WorkoutRoomMember> findByMember(Member member);
 
     @Query("SELECT wrm FROM WorkoutRoomMember wrm JOIN FETCH wrm.member WHERE wrm.workoutRoom = :workoutRoom ORDER BY wrm.joinedAt")
     List<WorkoutRoomMember> findByWorkoutRoomOrderByJoinedAtFetchMember(@Param("workoutRoom") WorkoutRoom workoutRoom);
-    boolean existsByMemberAndWorkoutRoom(Member member, WorkoutRoom workoutRoom);
-    List<WorkoutRoomMember> findWorkoutRoomMembersByMember(Member member);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update WorkoutRoomMember wrm set wrm.weeklyWorkouts = 0 where wrm.weeklyWorkouts <> 0")

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
@@ -80,7 +80,7 @@ public class WorkoutRoomService {
 
     @Transactional(readOnly = true)
     public List<WorkoutRoomResponse> getJoinedWorkoutRooms(Member member) {
-        return workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member).stream()
+        return workoutRoomMemberRepository.findByMember(member).stream()
                 .map(workoutRoomMember -> WorkoutRoomResponse.from(workoutRoomMember.getWorkoutRoom()))
                 .toList();
     }

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
@@ -38,7 +38,7 @@ public class WorkoutService {
     @CacheEvict(value = "workoutRoomDetail", allEntries = true)
     public WorkoutResponse authenticateWorkout(Member member, WorkoutRequest request) {
         LocalDate workoutDate = LocalDate.parse(request.getWorkoutDate(), DateTimeFormatter.ISO_LOCAL_DATE);
-        List<WorkoutRoomMember> wrms = workoutRoomMemberRepository.findWorkoutRoomMembersByMember(member);
+        List<WorkoutRoomMember> wrms = workoutRoomMemberRepository.findByMember(member);
         if (wrms.isEmpty()) {
             throw new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND);
         }

--- a/src/main/java/com/behcm/global/config/aws/S3Service.java
+++ b/src/main/java/com/behcm/global/config/aws/S3Service.java
@@ -74,6 +74,40 @@ public class S3Service {
         return false;
     }
 
+    /**
+     * 채팅 이미지 업로드. image/jpeg, image/png, image/webp만 허용, 최대 5MB.
+     * S3 키: chat/rooms/{roomId}/{yyyy/MM/dd}/{uuid}.{ext}
+     */
+    public String uploadChatImage(MultipartFile file, Long roomId) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_FILE);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !isAllowedProfileContentType(contentType)) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+        if (file.getSize() > PROFILE_IMAGE_MAX_SIZE_BYTES) {
+            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
+        }
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+        String fileName = generateFileName(originalFilename);
+        String filePath = "chat/rooms/" + roomId + "/" + getFolderName();
+        String key = filePath + "/" + fileName;
+        try (InputStream inputStream = file.getInputStream()) {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(contentType);
+            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata));
+            return getFileUrl(key);
+        } catch (IOException e) {
+            log.error("S3 채팅 이미지 업로드 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
     public String uploadImage(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_FILE);


### PR DESCRIPTION
Closes #77

## Description
- REST API: POST /api/chat/rooms/{roomId}/images — multipart 이미지 수신, S3 업로드 후 imageUrl 반환
- MIME/크기 검증 및 채팅방 멤버 검증
- S3Service 채팅 이미지 업로드 메서드 추가
- ChatMessage/ChatService 이미지 메시지 처리 및 브로드캐스트
- ChatImageUploadResponse DTO 및 스펙 문서 추가