### PR TITLE
운동 인증 이미지 S3 업로드 및 기록 로직 추가

### DIFF
--- a/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutService.java
@@ -57,7 +57,7 @@ public class WorkoutService {
         }
 
         // 여러 이미지 S3에 업로드
-        List<String> imageUrls = s3Service.uploadImages(request.getImages());
+        List<String> imageUrls = s3Service.uploadWorkoutImages(request.getImages());
         for (WorkoutRoomMember wrm : wrms) {
             WorkoutRoom workoutRoom = wrm.getWorkoutRoom();
             // 운동 기록 저장

--- a/src/main/java/com/behcm/global/config/aws/S3Service.java
+++ b/src/main/java/com/behcm/global/config/aws/S3Service.java
@@ -13,7 +13,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 @Service
@@ -21,141 +22,101 @@ import java.util.*;
 @Slf4j
 public class S3Service {
 
-    private static final long PROFILE_IMAGE_MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+    private static final long IMAGE_MAX_SIZE_BYTES = 20 * 1024 * 1024; // 20MB
     private static final String PROFILE_IMAGE_PREFIX = "profiles/";
-    private static final String[] PROFILE_ALLOWED_CONTENT_TYPES = {
-            "image/jpeg", "image/png", "image/webp"
-    };
+    private static final String CHAT_IMAGE_PREFIX = "chat/rooms/";
+    private static final String WORKOUT_IMAGE_PREFIX = "workout/";
+    private static final DateTimeFormatter FOLDER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy/MM/dd");
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of("image/jpeg", "image/png", "image/webp");
+    private static final Set<String> ALLOWED_IMAGE_EXTENSIONS = Set.of(".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp");
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
     private final AmazonS3Client amazonS3Client;
 
-    /**
-     * 프로필 이미지 업로드. image/jpeg, image/png, image/webp만 허용, 최대 5MB.
-     */
     public String uploadProfileImage(MultipartFile file) {
-        if (file == null || file.isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_FILE);
-        }
-        String contentType = file.getContentType();
-        if (contentType == null || !isAllowedProfileContentType(contentType)) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
-        if (file.getSize() > PROFILE_IMAGE_MAX_SIZE_BYTES) {
-            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
-        }
-        String originalFilename = file.getOriginalFilename();
-        if (originalFilename == null || !originalFilename.contains(".")) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
-        String fileName = generateFileName(originalFilename);
-        String filePath = PROFILE_IMAGE_PREFIX + getFolderName();
-        String key = filePath + "/" + fileName;
-        try (InputStream inputStream = file.getInputStream()) {
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(file.getSize());
-            objectMetadata.setContentType(contentType);
-            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata));
-            return getFileUrl(key);
-        } catch (IOException e) {
-            log.error("S3 프로필 이미지 업로드 실패: {}", e.getMessage(), e);
-            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
-        }
-    }
-
-    private boolean isAllowedProfileContentType(String contentType) {
-        for (String allowed : PROFILE_ALLOWED_CONTENT_TYPES) {
-            if (allowed.equalsIgnoreCase(contentType)) {
-                return true;
-            }
-        }
-        return false;
+        return uploadImage(file, PROFILE_IMAGE_PREFIX);
     }
 
     /**
-     * 채팅 이미지 업로드. image/jpeg, image/png, image/webp만 허용, 최대 5MB.
      * S3 키: chat/rooms/{roomId}/{yyyy/MM/dd}/{uuid}.{ext}
      */
     public String uploadChatImage(MultipartFile file, Long roomId) {
-        if (file == null || file.isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_FILE);
-        }
-        String contentType = file.getContentType();
-        if (contentType == null || !isAllowedProfileContentType(contentType)) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
-        if (file.getSize() > PROFILE_IMAGE_MAX_SIZE_BYTES) {
-            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
-        }
-        String originalFilename = file.getOriginalFilename();
-        if (originalFilename == null || !originalFilename.contains(".")) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
-        String fileName = generateFileName(originalFilename);
-        String filePath = "chat/rooms/" + roomId + "/" + getFolderName();
-        String key = filePath + "/" + fileName;
-        try (InputStream inputStream = file.getInputStream()) {
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(file.getSize());
-            objectMetadata.setContentType(contentType);
-            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata));
-            return getFileUrl(key);
-        } catch (IOException e) {
-            log.error("S3 채팅 이미지 업로드 실패: {}", e.getMessage(), e);
-            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
-        }
+        String prefix = CHAT_IMAGE_PREFIX + roomId + "/";
+        return uploadImage(file, prefix);
     }
 
-    public String uploadImage(MultipartFile file) {
-        if (file == null || file.isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_FILE);
-        }
-
-        // 파일 확장자 검증
-        String originalFilename = file.getOriginalFilename();
-        if (!isValidImageFile(originalFilename)) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
-
-        String uploadFileUrl;
-        String fileName = generateFileName(originalFilename);
-        String filePath = getFolderName();
-        String key = filePath + "/" +fileName;
-
-        try (InputStream inputStream = file.getInputStream()){
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(file.getSize());
-            objectMetadata.setContentType(file.getContentType());
-
-            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata));
-            uploadFileUrl = getFileUrl(key);
-
-            return uploadFileUrl;
-        } catch (IOException e) {
-            log.error("S3 파일 업로드 실패: {}", e.getMessage(), e);
-            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
-        }
-    }
-
-    public List<String> uploadImages(java.util.List<MultipartFile> files) {
+    public List<String> uploadWorkoutImages(List<MultipartFile> files) {
         if (files == null || files.isEmpty()) {
             throw new CustomException(ErrorCode.INVALID_FILE);
         }
 
         List<String> uploadedUrls = new ArrayList<>();
         for (MultipartFile file : files) {
-            String uploadedUrl = uploadImage(file);
+            String uploadedUrl = uploadWorkoutImage(file);
             uploadedUrls.add(uploadedUrl);
         }
         return uploadedUrls;
     }
 
+    private String uploadWorkoutImage(MultipartFile file) {
+        return uploadImage(file, WORKOUT_IMAGE_PREFIX);
+    }
+
+    private String uploadImage(MultipartFile file, String keyPrefix) {
+        if (file == null || file.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_FILE);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        if (file.getSize() > IMAGE_MAX_SIZE_BYTES) {
+            throw new CustomException(ErrorCode.FILE_TOO_LARGE);
+        }
+
+        if (!isAllowedContentType(file.getContentType())) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        if (!isValidImageFile(originalFilename)) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        String fileName = generateFileName(originalFilename);
+        String filePath = keyPrefix + getFolderName();
+        String key = filePath + "/" + fileName;
+
+        try (InputStream inputStream = file.getInputStream()) {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+
+            amazonS3Client.putObject(new PutObjectRequest(bucket, key, inputStream, objectMetadata));
+            return getFileUrl(key);
+        } catch (IOException e) {
+            log.error("S3 파일 업로드 실패: {}", e.getMessage(), e);
+            throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    private boolean isAllowedContentType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        String lowerCaseContentType = contentType.toLowerCase(Locale.ROOT);
+        return ALLOWED_CONTENT_TYPES.contains(lowerCaseContentType);
+    }
+
     private boolean isValidImageFile(String filename) {
-        String[] validExtensions = {".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp"};
-        String lowerCaseFilename = filename.toLowerCase();
-        for (String ext : validExtensions) {
+        if (filename == null) {
+            return false;
+        }
+        String lowerCaseFilename = filename.toLowerCase(Locale.ROOT);
+        for (String ext : ALLOWED_IMAGE_EXTENSIONS) {
             if (lowerCaseFilename.endsWith(ext)) {
                 return true;
             }
@@ -163,16 +124,12 @@ public class S3Service {
         return false;
     }
 
-    public String getFileUrl(String key) {
+    private String getFileUrl(String key) {
         return amazonS3Client.getUrl(bucket, key).toString();
     }
 
     private String getFolderName() {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
-        Date date = new Date();
-        String str = sdf.format(date);
-
-        return str.replace("-", "/");
+        return LocalDate.now().format(FOLDER_DATE_FORMATTER);
     }
 
     private String generateFileName(String originalFilename) {


### PR DESCRIPTION
Closes #80

## Description
운동 인증 기능을 위해 S3 이미지 업로드 및 운동 기록 저장 로직을 추가/수정했습니다.

- `S3Service`에 운동 인증용 이미지 업로드 메서드(`uploadWorkoutImages`)를 추가하고, 이미지 확장자/Content-Type/파일 크기(20MB) 검증 로직을 구현했습니다.
- 업로드 경로를 일별 폴더 구조(`yyyy/MM/dd`)로 관리하고, UUID 기반 파일명을 생성하여 충돌을 방지했습니다.
- `WorkoutService`에서 회원이 참여 중인 모든 운동방에 대해, 하루 한 번만 인증할 수 있도록 기존 운동 기록 중복 여부를 검사하는 로직을 추가했습니다.
- 여러 장의 인증 이미지를 S3에 업로드하고, 반환된 URL 목록을 운동 기록(`WorkoutRecord`)에 저장하도록 변경했습니다.
- 이번 주 운동 횟수 및 총 운동 일수 집계 로직을 보완하여, 주차별 통계가 정확히 계산되도록 했습니다.