### PR TITLE
운동 피드 기간 필터 및 저장소 쿼리 개선

### DIFF
--- a/.cursor/commands/github-issue-pr-command.md
+++ b/.cursor/commands/github-issue-pr-command.md
@@ -10,10 +10,11 @@ When I ask to "ship it", "deploy feature", or "start github workflow" regarding 
 
 1. Analyze the current code changes and summarize them.
 2. Resolve **owner** and **repo**: run `git remote -v` and parse the origin URL (e.g. `https://github.com/BellWin98/BE-HCM.git` → owner: `BellWin98`, repo: `BE-HCM`).
-3. Call MCP tool **create_issue** (**모든 텍스트 필드 `title`, `body`는 반드시 한국어로 작성할 것**):
+3. Call MCP tool **issue_write** (**모든 텍스트 필드 `title`, `body`는 반드시 한국어로 작성할 것**):
    - **Server**: `user-github`
-   - **Tool**: `create_issue`
+   - **Tool**: `issue_write`
    - **Arguments**:
+     - `method` (string): create
      - `owner` (string): repository owner
      - `repo` (string): repository name
      - `title` (string): concise summary of the feature or fix **(Korean only)**

--- a/mdfiles/workoutFeed.md
+++ b/mdfiles/workoutFeed.md
@@ -1,0 +1,143 @@
+## 마이페이지 운동 인증 피드 기간 필터 백엔드 작업 정리
+
+### 1. 개요
+
+- 마이페이지 `운동 인증 피드`에서 프론트가 **기간 필터(전체 / 이번 주 / 이번 달)** 를 선택해 조회할 수 있도록 백엔드에서 기간 필터링을 지원해야 합니다.
+- 프론트는 `/api/members/workout-feed` 엔드포인트에 **`periodType` 쿼리 파라미터**를 추가로 보내고, 응답은 기존과 동일한 **페이지 응답(`PageResponse<WorkoutFeedItem>`)** 형태를 유지합니다.
+
+---
+
+### 2. 프론트엔드에서 사용하는 API 스펙
+
+- 요청 메서드: `GET`
+- 엔드포인트: `/api/members/workout-feed`
+- 쿼리 파라미터:
+  - **필수**
+    - `page`: `number` (0-base 페이지 번호)
+    - `size`: `number` (페이지 크기)
+  - **선택**
+    - `periodType`: `"ALL" | "WEEK" | "MONTH"`
+      - 미전달 또는 `"ALL"`인 경우: **전체 기간** 대상으로 페이징
+      - `"WEEK"`인 경우: **이번 주(현재 날짜 기준)** 운동 인증만 대상으로 페이징
+      - `"MONTH"`인 경우: **이번 달(현재 날짜 기준)** 운동 인증만 대상으로 페이징
+
+#### 프론트 코드 기준 호출 형태
+
+- 초기 로딩 (전체 보기):
+  - `GET /api/members/workout-feed?page=0&size=20&periodType=ALL`
+- 기간 변경 시:
+  - 전체: `GET /api/members/workout-feed?page=0&size=20&periodType=ALL`
+  - 이번 주: `GET /api/members/workout-feed?page=0&size=20&periodType=WEEK`
+  - 이번 달: `GET /api/members/workout-feed?page=0&size=20&periodType=MONTH`
+- 더보기(무한 스크롤):
+  - 동일한 `periodType`으로 `page`만 증가시키면서 호출  
+    예) `page=1`, `page=2` …
+
+---
+
+### 3. 응답 스펙 (변경 없음)
+
+- 응답 타입: `PageResponse<WorkoutFeedItem>`
+- JSON 예시:
+
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "workoutDate": "2026-03-10",
+      "workoutTypes": ["헬스(가슴)", "러닝"],
+      "duration": 60,
+      "imageUrls": ["https://.../image1.jpg"],
+      "description": "가슴 + 러닝",
+      "likes": 10,
+      "comments": 2,
+      "isLiked": false,
+      "createdAt": "2026-03-10T10:00:00",
+      "roomName": "평일 헬스방"
+    }
+  ],
+  "last": false,
+  "totalPages": 5,
+  "number": 0,
+  "size": 20
+}
+```
+
+- **주의점**
+  - 프론트는 `content` 배열이 비어 있으면 더 이상 데이터가 없다고 판단하고, `last` 플래그가 `true`인 경우에도 추가 로딩을 중단합니다.
+  - 타입 구조는 기존 구현과 동일하게 유지해야 합니다.
+
+---
+
+### 4. 기간 필터링 로직 정의
+
+#### 4.1. 기준 날짜
+
+- 기준: **현재 서버 시각(LocalDate.now 또는 ZonedDateTime.now 기준)**
+  - 회원별 타임존 처리가 필요하면, 회원/요청 기준 타임존으로 변환 후 계산.
+
+#### 4.2. 기간 범위 정의
+
+- `periodType = "ALL"`
+  - 기간 필터 적용하지 않음.
+
+- `periodType = "WEEK"`
+  - **이번 주의 시작 ~ 끝** 범위만 포함.
+  - 기준:
+    - 주 시작: 일반적으로 **월요일** 기준 (백엔드/도메인 규칙에 맞게 결정)
+    - 예) `2026-03-12(목)` 기준
+      - 주 시작: `2026-03-09(월)`
+      - 주 끝: `2026-03-15(일)`
+  - 조건 예:
+    - `workoutDate BETWEEN weekStart AND weekEnd`
+
+- `periodType = "MONTH"`
+  - **이번 달 1일 ~ 말일** 범위만 포함.
+  - 예) `2026-03-12` 기준
+    - 월 시작: `2026-03-01`
+    - 월 끝: `2026-03-31`
+  - 조건 예:
+    - `workoutDate BETWEEN monthStart AND monthEnd`
+
+#### 4.3. 정렬 및 페이징
+
+- 정렬:
+  - 기본: `workoutDate DESC`, `createdAt DESC` 등 최신 운동이 위로 오도록 정렬.
+  - 프론트는 이 정렬 순서에 의존해 단순히 페이지를 이어붙입니다.
+- 페이징:
+  - JPA/Pageable 또는 직접 LIMIT/OFFSET 방식으로 구현 시:
+    - WHERE 절에 `periodType`에 따른 날짜 범위를 추가한 뒤, **그 결과에 대해 페이지네이션**.
+  - 즉, 기간 필터 → 정렬 → 페이징 순서로 계산.
+
+---
+
+### 5. 예외/엣지 케이스 처리
+
+- `periodType` 값이 지정되지 않았거나 `"ALL"`인 경우:
+  - 기존 구현과 동일하게 전체 기간 대상으로 동작.
+- `periodType`가 `"ALL" | "WEEK" | "MONTH"` 이외의 값인 경우:
+  - 옵션 1: 400 Bad Request 반환 (권장)
+  - 옵션 2: `"ALL"`로 강제 처리 (짧은 기간 내 임시 대응용)
+- 해당 기간에 운동 인증이 하나도 없는 경우:
+  - `content: []`, `last: true`, `totalPages: 0`, `number: 0` 등의 형태로 응답.
+  - 프론트는 "아직 운동 인증이 없습니다." UI를 그대로 사용.
+
+---
+
+### 6. 구현 포인트 요약
+
+- [ ] `/api/members/workout-feed` 컨트롤러/핸들러에 `periodType` 쿼리 파라미터 추가
+  - 타입: enum 또는 `String` → enum 변환
+- [ ] 서비스 계층에서 `periodType`에 따라 날짜 범위 계산
+  - `ALL`: 필터 없음
+  - `WEEK`: 이번 주 시작/끝 계산
+  - `MONTH`: 이번 달 시작/끝 계산
+- [ ] 레포지토리(쿼리)에서:
+  - 회원 ID + (선택적으로) 날짜 범위를 조건으로 조회
+  - `Pageable` 인자로 `page`, `size`, 정렬 기준 적용
+- [ ] 응답은 기존과 동일한 `Page<WorkoutFeedItem>` → `PageResponse<WorkoutFeedItem>` 형태로 변환
+- [ ] 단위/통합 테스트
+  - `periodType`별로:
+    - 다른 주/다른 달 데이터가 섞여 들어오지 않는지 확인
+    - `last` 플래그 및 `totalPages` 계산이 정상인지 확인

--- a/src/main/java/com/behcm/domain/member/controller/MemberController.java
+++ b/src/main/java/com/behcm/domain/member/controller/MemberController.java
@@ -4,7 +4,7 @@ import com.behcm.domain.member.dto.*;
 import com.behcm.domain.member.entity.Member;
 import com.behcm.domain.member.service.MemberService;
 import com.behcm.domain.workout.dto.WorkoutFeedItemResponse;
-import com.behcm.domain.workout.dto.WorkoutStatsResponse;
+import com.behcm.domain.workout.enums.PeriodType;
 import com.behcm.global.common.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -60,9 +60,11 @@ public class MemberController {
     public ResponseEntity<ApiResponse<Page<WorkoutFeedItemResponse>>> getMemberWorkoutFeed(
             @AuthenticationPrincipal Member member,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String periodType
     ) {
-        Page<WorkoutFeedItemResponse> response = memberService.getMemberWorkoutFeed(member, page, size);
+        PeriodType period = PeriodType.from(periodType);
+        Page<WorkoutFeedItemResponse> response = memberService.getMemberWorkoutFeed(member, page, size, period);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/behcm/domain/member/service/MemberService.java
+++ b/src/main/java/com/behcm/domain/member/service/MemberService.java
@@ -6,14 +6,13 @@ import com.behcm.domain.member.entity.MemberSettings;
 import com.behcm.domain.member.repository.MemberRepository;
 import com.behcm.domain.member.repository.MemberSettingsRepository;
 import com.behcm.domain.workout.dto.WorkoutFeedItemResponse;
+import com.behcm.domain.workout.enums.PeriodType;
 import com.behcm.domain.workout.entity.WorkoutRecord;
 import com.behcm.domain.workout.repository.WorkoutRecordRepository;
 import com.behcm.global.config.aws.S3Service;
 import com.behcm.global.exception.CustomException;
 import com.behcm.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.time.DayOfWeek;
+import java.time.YearMonth;
 import java.util.Comparator;
 import java.util.List;
 
@@ -68,9 +69,35 @@ public class MemberService {
         return MemberProfileResponse.from(savedMember, currentStreak, longestStreak);
     }
 
-    public Page<WorkoutFeedItemResponse> getMemberWorkoutFeed(Member member, int page, int size) {
+    public Page<WorkoutFeedItemResponse> getMemberWorkoutFeed(Member member, int page, int size, PeriodType periodType) {
         Pageable pageable = PageRequest.of(page, size);
-        return workoutRecordRepository.findAllByMemberPerWorkoutDate(member, pageable).map(WorkoutFeedItemResponse::from);
+
+        PeriodType effectivePeriodType = periodType == null ? PeriodType.ALL : periodType;
+        LocalDate today = LocalDate.now();
+
+        LocalDate startDate;
+        LocalDate endDate;
+
+        if (effectivePeriodType == PeriodType.WEEK) {
+            LocalDate weekStart = today.with(DayOfWeek.MONDAY);
+            if (today.getDayOfWeek().getValue() < DayOfWeek.MONDAY.getValue()) {
+                weekStart = today.minusDays(today.getDayOfWeek().getValue() + (7 - DayOfWeek.MONDAY.getValue()));
+            }
+            startDate = weekStart;
+            endDate = weekStart.plusDays(6);
+        } else {
+            YearMonth currentMonth = YearMonth.from(today);
+            startDate = currentMonth.atDay(1);
+            endDate = currentMonth.atEndOfMonth();
+        }
+
+        if (effectivePeriodType == PeriodType.ALL) {
+            return workoutRecordRepository.findAllByMemberPerWorkoutDate(member, pageable)
+                    .map(WorkoutFeedItemResponse::from);
+        }
+
+        return workoutRecordRepository.findAllByMemberPerWorkoutDateAndWorkoutDateBetween(member, startDate, endDate, pageable)
+                .map(WorkoutFeedItemResponse::from);
     }
 
     @Transactional

--- a/src/main/java/com/behcm/domain/workout/enums/PeriodType.java
+++ b/src/main/java/com/behcm/domain/workout/enums/PeriodType.java
@@ -1,0 +1,21 @@
+package com.behcm.domain.workout.enums;
+
+public enum PeriodType {
+
+    ALL,
+    WEEK,
+    MONTH;
+
+    public static PeriodType from(String value) {
+        if (value == null || value.isBlank()) {
+            return ALL;
+        }
+
+        try {
+            return PeriodType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return ALL;
+        }
+    }
+}
+

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRecordRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRecordRepository.java
@@ -31,7 +31,23 @@ public interface WorkoutRecordRepository extends JpaRepository<WorkoutRecord, Lo
                 order by wr.workoutDate desc
             """
     )
-    List<WorkoutRecord> findAllByMemberPerWorkoutDate(Member member);
+    List<WorkoutRecord> findAllByMemberPerWorkoutDate(@Param("member") Member member);
+
+    @Query(
+            """
+                select wr
+                from WorkoutRecord wr
+                where wr.member = :member
+                and wr.createdAt = (
+                    select max(wr2.createdAt)
+                    from WorkoutRecord wr2
+                    where wr2.member = wr.member
+                    and wr2.workoutDate = wr.workoutDate
+                )
+                order by wr.workoutDate desc
+            """
+    )
+    Page<WorkoutRecord> findAllByMemberPerWorkoutDate(@Param("member") Member member, Pageable pageable);
 
     Optional<WorkoutRecord> findByMemberAndWorkoutRoomAndWorkoutDate(Member member, WorkoutRoom workoutRoom, LocalDate today);
     boolean existsByMemberAndWorkoutRoomAndWorkoutDate(Member member, WorkoutRoom workoutRoom, LocalDate workoutDate);
@@ -72,6 +88,7 @@ public interface WorkoutRecordRepository extends JpaRepository<WorkoutRecord, Lo
                 select wr
                 from WorkoutRecord wr
                 where wr.member = :member
+                and wr.workoutDate >= :startDate and wr.workoutDate <= :endDate
                 and wr.createdAt = (
                     select max(wr2.createdAt)
                     from WorkoutRecord wr2
@@ -81,7 +98,12 @@ public interface WorkoutRecordRepository extends JpaRepository<WorkoutRecord, Lo
                 order by wr.workoutDate desc
             """
     )
-    Page<WorkoutRecord> findAllByMemberPerWorkoutDate(Member member, Pageable pageable);
+    Page<WorkoutRecord> findAllByMemberPerWorkoutDateAndWorkoutDateBetween(
+            @Param("member") Member member,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
+    );
 
     void deleteByMember(Member member);
 

--- a/src/test/java/com/behcm/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/behcm/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,113 @@
+package com.behcm.domain.member.service;
+
+import com.behcm.domain.member.entity.Member;
+import com.behcm.domain.member.repository.MemberRepository;
+import com.behcm.domain.member.repository.MemberSettingsRepository;
+import com.behcm.domain.workout.dto.WorkoutFeedItemResponse;
+import com.behcm.domain.workout.enums.PeriodType;
+import com.behcm.domain.workout.entity.WorkoutRecord;
+import com.behcm.domain.workout.repository.WorkoutRecordRepository;
+import com.behcm.global.config.aws.S3Service;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private WorkoutRecordRepository workoutRecordRepository;
+
+    @Mock
+    private MemberSettingsRepository memberSettingsRepository;
+
+    @Mock
+    private S3Service s3Service;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("getMemberWorkoutFeed는 periodType이 ALL이거나 null이면 전체 기간을 조회한다")
+    void getMemberWorkoutFeed_allPeriod() {
+        // given
+        Member member = Member.builder()
+                .email("test@example.com")
+                .password("password")
+                .nickname("tester")
+                .build();
+        int page = 0;
+        int size = 10;
+        Pageable pageable = PageRequest.of(page, size);
+
+        WorkoutRecord record = WorkoutRecord.builder()
+                .member(member)
+                .workoutDate(LocalDate.now())
+                .duration(30)
+                .build();
+        Page<WorkoutRecord> recordPage = new PageImpl<>(List.of(record), pageable, 1);
+
+        given(workoutRecordRepository.findAllByMemberPerWorkoutDate(member, pageable)).willReturn(recordPage);
+
+        // when
+        Page<WorkoutFeedItemResponse> result = memberService.getMemberWorkoutFeed(member, page, size, PeriodType.ALL);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        verify(workoutRecordRepository).findAllByMemberPerWorkoutDate(member, pageable);
+    }
+
+    @Test
+    @DisplayName("getMemberWorkoutFeed는 periodType이 WEEK/MONTH이면 해당 기간만 조회한다")
+    void getMemberWorkoutFeed_weekAndMonthPeriod() {
+        // given
+        Member member = Member.builder()
+                .email("test2@example.com")
+                .password("password")
+                .nickname("tester2")
+                .build();
+        int page = 0;
+        int size = 10;
+        Pageable pageable = PageRequest.of(page, size);
+
+        WorkoutRecord record = WorkoutRecord.builder()
+                .member(member)
+                .workoutDate(LocalDate.now())
+                .duration(30)
+                .build();
+        Page<WorkoutRecord> recordPage = new PageImpl<>(List.of(record), pageable, 1);
+
+        given(workoutRecordRepository.findAllByMemberPerWorkoutDateAndWorkoutDateBetween(
+                org.mockito.Mockito.eq(member),
+                org.mockito.Mockito.any(LocalDate.class),
+                org.mockito.Mockito.any(LocalDate.class),
+                org.mockito.Mockito.eq(pageable)
+        )).willReturn(recordPage);
+
+        // when
+        Page<WorkoutFeedItemResponse> weekResult = memberService.getMemberWorkoutFeed(member, page, size, PeriodType.WEEK);
+        Page<WorkoutFeedItemResponse> monthResult = memberService.getMemberWorkoutFeed(member, page, size, PeriodType.MONTH);
+
+        // then
+        assertThat(weekResult.getContent()).hasSize(1);
+        assertThat(monthResult.getContent()).hasSize(1);
+    }
+}
+


### PR DESCRIPTION
Closes #83

## Description
회원 운동 피드 조회 API에 기간 필터 기능을 추가하고, 저장소 쿼리를 개선했습니다.

- `MemberController`에 `periodType` 요청 파라미터를 추가하여 전체/주간/월간 기간 선택 지원
- `PeriodType` enum을 신설하여 기간 타입을 명시적으로 관리
- `MemberService.getMemberWorkoutFeed`에서 기간 타입에 따라 시작일/종료일을 계산하고, 기간 조건이 있는 조회 메서드를 사용하도록 변경
- `WorkoutRecordRepository`에 페이징 및 기간조건이 포함된 쿼리 메서드를 추가하여 최신 기록 기준 조회 및 성능 개선
- 테스트 코드(`MemberServiceTest`)를 추가/보완하여 새로운 기간 필터 로직을 검증

이 PR을 통해 회원 운동 피드를 기간별로 안정적으로 조회할 수 있으며, 최신 기록 기준으로 올바르게 페이징됩니다.