### PR TITLE
워크아웃 방 멤버 응답 DTO에 bio 필드 추가

### DIFF
--- a/src/main/java/com/behcm/domain/workout/dto/WorkoutRoomMemberResponse.java
+++ b/src/main/java/com/behcm/domain/workout/dto/WorkoutRoomMemberResponse.java
@@ -14,6 +14,7 @@ public class WorkoutRoomMemberResponse {
     private Long id;
     private String nickname;
     private String profileUrl;
+    private String bio;
     private Integer totalWorkouts;
     private Integer weeklyWorkouts;
     private Long totalPenalty;
@@ -31,6 +32,7 @@ public class WorkoutRoomMemberResponse {
                 .id(workoutRoomMember.getId())
                 .nickname(workoutRoomMember.getNickname())
                 .profileUrl(workoutRoomMember.getMember().getProfileUrl())
+                .bio(workoutRoomMember.getMember().getBio())
                 .totalWorkouts(workoutRoomMember.getTotalWorkouts())
                 .weeklyWorkouts(workoutRoomMember.getWeeklyWorkouts())
                 .totalPenalty(workoutRoomMember.getTotalPenalty())


### PR DESCRIPTION
Closes #86

## Description
`WorkoutRoomMemberResponse` DTO에 멤버의 소개(bio) 정보를 포함하도록 필드를 추가했습니다.

- DTO 필드에 `bio` 문자열 필드 추가
- 정적 팩토리 메서드에서 `workoutRoomMember.getMember().getBio()` 값을 매핑하여 응답에 포함

해당 변경으로 워크아웃 방 멤버 정보를 조회하는 API 응답에 사용자 소개(bio)가 함께 노출되며, 프론트엔드에서 프로필 영역에 소개 문구를 표시할 수 있습니다.