### PR TITLE
3인 운동방 채팅 읽음/안읽음 카운트가 1에서 사라지지 않는 문제 수정

### DIFF
--- a/.cursor/commands/github-issue-pr-command.md
+++ b/.cursor/commands/github-issue-pr-command.md
@@ -13,12 +13,16 @@ When I ask to "ship it", "deploy feature", or "start github workflow" regarding 
 3. Call MCP tool **issue_write** (**모든 텍스트 필드 `title`, `body`는 반드시 한국어로 작성할 것**):
    - **Server**: `user-github`
    - **Tool**: `issue_write`
-   - **Arguments**:
-     - `method` (string): 'create'
-     - `owner` (string): repository owner
-     - `repo` (string): repository name
-     - `title` (string): concise summary of the feature or fix **(Korean only)**
-     - `body` (string): detailed description of the implementation **(Korean only)**
+   - **Arguments** (아래 모든 key-value를 하나의 `arguments` JSON 객체로 전달):
+     ```json
+     {
+       "method": "create",
+       "owner": "<repository owner>",
+       "repo": "<repository name>",
+       "title": "<concise summary of the feature or fix (Korean only)>",
+       "body": "<detailed description of the implementation (Korean only)>"
+     }
+     ```
 4. **IMPORTANT**: Remember the returned `number` (issue_number) from the response.
 
 ---

--- a/src/main/java/com/behcm/domain/chat/service/ChatService.java
+++ b/src/main/java/com/behcm/domain/chat/service/ChatService.java
@@ -77,6 +77,16 @@ public class ChatService {
 
         ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
+        // 보낸 사람은 해당 메시지를 즉시 읽은 것으로 간주하여 lastReadMessage 갱신
+        WorkoutRoomMember senderWorkoutRoomMember = workoutRoomMemberRepository
+                .findByWorkoutRoomAndMember(workoutRoom, sender)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_WORKOUT_ROOM_MEMBER));
+        ChatMessage senderCurrentLastRead = senderWorkoutRoomMember.getLastReadMessage();
+        if (senderCurrentLastRead == null || senderCurrentLastRead.getId() < savedChatMessage.getId()) {
+            senderWorkoutRoomMember.setLastReadMessage(savedChatMessage);
+            workoutRoomMemberRepository.save(senderWorkoutRoomMember);
+        }
+
         List<ChatMessageResponse> responses = toResponsesWithUnread(workoutRoom, List.of(savedChatMessage));
         ChatMessageResponse response = responses.isEmpty() ? ChatMessageResponse.from(savedChatMessage) : responses.getFirst();
 
@@ -129,7 +139,7 @@ public class ChatService {
         }
 
         // 최신 읽음 상태를 기반으로 최근 메시지들의 unreadCount를 재계산하여 브로드캐스트
-        Pageable pageable = PageRequest.of(0, 50);
+        Pageable pageable = PageRequest.of(0, 200);
         List<ChatMessage> recentMessages =
                 chatMessageRepository.findByWorkoutRoomOrderByIdDesc(wrm.getWorkoutRoom(), pageable);
 


### PR DESCRIPTION
Closes #93

## Description
3명이 있는 운동방에서 채팅 읽음/안읽음 카운트를 계산할 때, 세 명 모두 채팅방에 들어와 메시지를 읽었음에도 불구하고 `unreadCount`가 1에서 사라지지 않는 버그를 수정했습니다.

- `ChatService.sendMessage`에서 메시지 저장 직후, 보낸 사용자의 `WorkoutRoomMember.lastReadMessage`를 해당 메시지로 갱신하여 보낸 사람은 즉시 읽은 것으로 간주되도록 했습니다.
- `ChatService.updateLastReadMessage`에서 읽음 상태 브로드캐스트 시 재계산 대상이 되는 최근 메시지 범위를 50개에서 200개로 확장했습니다.
- 기존 `toResponsesWithUnread`의 `lastReadMessage` 기준 unreadCount 계산 로직은 유지하면서, 3인 방에서도 실제 읽음 상태가 더 정확히 반영되도록 조정했습니다.

이를 통해 2인 방과 마찬가지로 3인 방에서도 모든 멤버가 메시지를 읽은 경우 숫자가 사라지도록 동작합니다.