### PR TITLE
GitHub 워크플로우 자동화 명령 수정

### DIFF
--- a/.cursor/commands/github-issue-pr-command.md
+++ b/.cursor/commands/github-issue-pr-command.md
@@ -13,12 +13,16 @@ When I ask to "ship it", "deploy feature", or "start github workflow" regarding 
 3. Call MCP tool **issue_write** (**모든 텍스트 필드 `title`, `body`는 반드시 한국어로 작성할 것**):
    - **Server**: `user-github`
    - **Tool**: `issue_write`
-   - **Arguments**:
-     - `method` (string): 'create'
-     - `owner` (string): repository owner
-     - `repo` (string): repository name
-     - `title` (string): concise summary of the feature or fix **(Korean only)**
-     - `body` (string): detailed description of the implementation **(Korean only)**
+   - **Arguments** (아래 모든 key-value를 하나의 `arguments` JSON 객체로 전달):
+     ```json
+     {
+       "method": "create",
+       "owner": "<repository owner>",
+       "repo": "<repository name>",
+       "title": "<concise summary of the feature or fix (Korean only)>",
+       "body": "<detailed description of the implementation (Korean only)>"
+     }
+     ```
 4. **IMPORTANT**: Remember the returned `number` (issue_number) from the response.
 
 ---


### PR DESCRIPTION
Closes #95

## Description
`.cursor/commands/github-issue-pr-command.md` 파일에서 GitHub MCP 기반 이슈/PR 자동 생성 워크플로우 명령을 개선했습니다.

- issue_write 호출 시 arguments JSON 객체 예시를 명시적으로 추가하여 사용 방법을 더 명확히 했습니다.
- 한국어 전용 title/body 규칙을 주석에 강조했습니다.
- 전체 ship it / deploy feature / start github workflow 플로우를 문서화해 협업자가 쉽게 재사용할 수 있도록 했습니다.