### PR TITLE
운동방 기간(start/end) 필드 제거 및 통계 집계 로직 수정

### DIFF
--- a/src/main/java/com/behcm/domain/admin/workout/dto/AdminUpdateRoomRequest.java
+++ b/src/main/java/com/behcm/domain/admin/workout/dto/AdminUpdateRoomRequest.java
@@ -5,16 +5,8 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
-import java.time.LocalDate;
-
 @Data
 public class AdminUpdateRoomRequest {
-
-    @NotNull(message = "시작일은 필수입니다.")
-    private LocalDate startDate;
-
-    @NotNull(message = "종료일은 필수입니다.")
-    private LocalDate endDate;
 
     @NotNull(message = "최대 인원은 필수입니다.")
     @Min(value = 2, message = "최대 인원은 2명 이상이어야 합니다.")

--- a/src/main/java/com/behcm/domain/admin/workout/service/AdminWorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/admin/workout/service/AdminWorkoutRoomService.java
@@ -24,8 +24,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -63,7 +61,6 @@ public class AdminWorkoutRoomService {
                 })
                 .toList();
 
-        // Admin 조회에서는 특정 "현재 회원" 개념이 없으므로 오늘 운동 기록은 null로 반환
         return new WorkoutRoomDetailResponse(WorkoutRoomResponse.from(workoutRoom), workoutRoomMembers, null);
     }
 
@@ -72,22 +69,10 @@ public class AdminWorkoutRoomService {
         WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
 
-        LocalDate startDate = request.getStartDate();
-        LocalDate endDate = request.getEndDate();
-
-        if (startDate.isBefore(LocalDate.now())) {
-            throw new CustomException(ErrorCode.INVALID_INPUT, "시작 날짜는 오늘 이후여야 합니다.");
-        }
-        if (endDate != null && endDate.isBefore(startDate)) {
-            throw new CustomException(ErrorCode.INVALID_INPUT, "종료 날짜는 시작 날짜보다 뒤여야 합니다.");
-        }
-
         workoutRoom.updateRoomSettings(
                 workoutRoom.getName(),
                 request.getMinWeeklyWorkouts(),
                 request.getPenaltyPerMiss(),
-                startDate,
-                endDate,
                 request.getMaxMembers(),
                 workoutRoom.getEntryCode()
         );
@@ -98,35 +83,27 @@ public class AdminWorkoutRoomService {
 
     @Transactional
     public void deleteRoom(Long roomId) {
-        // 삭제 대상 운동방 조회
         WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
 
-        // WorkoutRoomMember의 Rest 삭제
         List<WorkoutRoomMember> members = workoutRoomMemberRepository.findByWorkoutRoomOrderByJoinedAt(workoutRoom);
         for (WorkoutRoomMember wrm : members) {
             List<Rest> rests = restRepository.findAllByWorkoutRoomMember(wrm);
             restRepository.deleteAll(rests);
         }
 
-        // WorkoutRecord 삭제
         workoutRecordRepository.deleteByWorkoutRoom(workoutRoom);
 
-        // ChatMessage 삭제
         chatMessageRepository.deleteByWorkoutRoom(workoutRoom);
 
-        // Penalty 삭제
         List<Penalty> penalties = penaltyRepository.findAllByWorkoutRoomId(workoutRoom.getId());
         penaltyRepository.deleteAll(penalties);
 
-        // PenaltyAccount 삭제
         penaltyAccountRepository.findByWorkoutRoom(workoutRoom)
                 .ifPresent(penaltyAccountRepository::delete);
 
-        // WorkoutRoomMember는 CASCADE로 자동 삭제되지만 명시적으로 처리
         workoutRoomMemberRepository.deleteAll(members);
 
-        // 운동방 삭제
         workoutRoomRepository.delete(workoutRoom);
     }
 }

--- a/src/main/java/com/behcm/domain/stats/service/StatsService.java
+++ b/src/main/java/com/behcm/domain/stats/service/StatsService.java
@@ -20,7 +20,7 @@ public class StatsService {
     public LandingStatsResponse getLandingStats() {
         long totalUsers = memberRepository.count();
         long totalExerciseProofs = workoutRecordRepository.count();
-        long activeRooms = workoutRoomRepository.countActiveRooms(LocalDate.now());
+        long activeRooms = workoutRoomRepository.countActiveRooms();
 
         return LandingStatsResponse.of(totalUsers, totalExerciseProofs, activeRooms);
     }

--- a/src/main/java/com/behcm/domain/workout/dto/CreateWorkoutRoomRequest.java
+++ b/src/main/java/com/behcm/domain/workout/dto/CreateWorkoutRoomRequest.java
@@ -1,9 +1,12 @@
 package com.behcm.domain.workout.dto;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
-
-import java.time.LocalDate;
 
 @Data
 public class CreateWorkoutRoomRequest {
@@ -19,10 +22,6 @@ public class CreateWorkoutRoomRequest {
     @NotNull(message = "회당 벌금은 필수입니다.")
     @Min(value = 1000, message = "회당 벌금은 1000원 이상이어야 합니다.")
     private Long penaltyPerMiss;
-
-    // @NotNull(message = "시작일은 필수입니다.")
-    private LocalDate startDate;
-    private LocalDate endDate;
 
     @NotNull(message = "최대 인원은 필수입니다.")
     @Min(value = 1, message = "최대 인원은 1명 이상이어야 합니다.")

--- a/src/main/java/com/behcm/domain/workout/dto/CreateWorkoutRoomRequest.java
+++ b/src/main/java/com/behcm/domain/workout/dto/CreateWorkoutRoomRequest.java
@@ -20,12 +20,12 @@ public class CreateWorkoutRoomRequest {
     @Min(value = 1000, message = "회당 벌금은 1000원 이상이어야 합니다.")
     private Long penaltyPerMiss;
 
-//    @NotNull(message = "시작일은 필수입니다.")
+    // @NotNull(message = "시작일은 필수입니다.")
     private LocalDate startDate;
     private LocalDate endDate;
 
     @NotNull(message = "최대 인원은 필수입니다.")
-    @Min(value = 2, message = "최대 인원은 2명 이상이어야 합니다.")
+    @Min(value = 1, message = "최대 인원은 1명 이상이어야 합니다.")
     private Integer maxMembers;
 
     @NotEmpty(message = "방 입장 코드는 필수입니다.")

--- a/src/main/java/com/behcm/domain/workout/dto/WorkoutRoomResponse.java
+++ b/src/main/java/com/behcm/domain/workout/dto/WorkoutRoomResponse.java
@@ -4,7 +4,6 @@ import com.behcm.domain.workout.entity.WorkoutRoom;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
@@ -14,10 +13,8 @@ public class WorkoutRoomResponse {
     private Long id;
     private String name;
     private String ownerNickname;
-    private Integer minWeeklyWorkouts; // 1주당 최소 운동 인증 횟수
+    private Integer minWeeklyWorkouts;
     private Long penaltyPerMiss;
-    private LocalDate startDate;
-    private LocalDate endDate;
     private Integer maxMembers;
     private Integer currentMembers;
     private Boolean isActive;
@@ -38,8 +35,6 @@ public class WorkoutRoomResponse {
                 .name(workoutRoom.getName())
                 .minWeeklyWorkouts(workoutRoom.getMinWeeklyWorkouts())
                 .penaltyPerMiss(workoutRoom.getPenaltyPerMiss())
-                .startDate(workoutRoom.getStartDate())
-                .endDate(workoutRoom.getEndDate())
                 .maxMembers(workoutRoom.getMaxMembers())
                 .currentMembers(workoutRoom.getCurrentMemberCount())
                 .ownerNickname(workoutRoom.getOwnerNickname())

--- a/src/main/java/com/behcm/domain/workout/entity/WorkoutRoom.java
+++ b/src/main/java/com/behcm/domain/workout/entity/WorkoutRoom.java
@@ -32,10 +32,6 @@ public class WorkoutRoom extends BaseTimeEntity {
     @Column(nullable = false, length = 10, unique = true)
     private String entryCode;
 
-//    @Column(nullable = false)
-    private LocalDate startDate;
-    private LocalDate endDate;
-
     @Column(nullable = false)
     private Integer maxMembers;
 
@@ -51,12 +47,10 @@ public class WorkoutRoom extends BaseTimeEntity {
 
     @Builder
     public WorkoutRoom(String name, Integer minWeeklyWorkouts, Long penaltyPerMiss,
-                       LocalDate startDate, LocalDate endDate, Integer maxMembers, String entryCode, Member owner) {
+                       Integer maxMembers, String entryCode, Member owner) {
         this.name = name;
         this.minWeeklyWorkouts = minWeeklyWorkouts;
         this.penaltyPerMiss = penaltyPerMiss;
-        this.startDate = startDate;
-        this.endDate = endDate;
         this.maxMembers = maxMembers;
         this.entryCode = entryCode;
         this.owner = owner;
@@ -67,12 +61,10 @@ public class WorkoutRoom extends BaseTimeEntity {
     }
 
     public void updateRoomSettings(String name, Integer minWeeklyWorkouts, Long penaltyPerMiss,
-                                   LocalDate startDate, LocalDate endDate, Integer maxMembers, String entryCode) {
+                                   Integer maxMembers, String entryCode) {
         this.name = name;
         this.minWeeklyWorkouts = minWeeklyWorkouts;
         this.penaltyPerMiss = penaltyPerMiss;
-        this.startDate = startDate;
-        this.endDate = endDate;
         this.maxMembers = maxMembers;
         this.entryCode = entryCode;
     }
@@ -82,10 +74,6 @@ public class WorkoutRoom extends BaseTimeEntity {
     }
 
     public boolean canJoin() {
-        if (endDate != null) {
-            return isActive && workoutRoomMembers.size() < maxMembers &&
-                    (LocalDate.now().isBefore(endDate));
-        }
         return isActive && workoutRoomMembers.size() < maxMembers;
     }
 

--- a/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomRepository.java
+++ b/src/main/java/com/behcm/domain/workout/repository/WorkoutRoomRepository.java
@@ -1,7 +1,8 @@
 package com.behcm.domain.workout.repository;
 
-import com.behcm.domain.member.entity.Member;
-import com.behcm.domain.workout.entity.WorkoutRoom;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,14 +10,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
+import com.behcm.domain.member.entity.Member;
+import com.behcm.domain.workout.entity.WorkoutRoom;
 
 @Repository
 public interface WorkoutRoomRepository extends JpaRepository<WorkoutRoom, Long> {
 
-    @Query("SELECT wr FROM WorkoutRoom wr WHERE wr.isActive = true AND (wr.endDate IS NULL OR wr.endDate >= CURRENT_DATE)")
+    @Query("SELECT wr FROM WorkoutRoom wr WHERE wr.isActive = true")
     List<WorkoutRoom> findActiveRooms();
 
     List<WorkoutRoom> findByIsActiveTrue();
@@ -27,32 +27,27 @@ public interface WorkoutRoomRepository extends JpaRepository<WorkoutRoom, Long> 
 
     Optional<WorkoutRoom> findByIdAndIsActiveTrue(Long roomId);
 
-    @Query(
-            """
-                    SELECT wr
-                    FROM WorkoutRoom wr
-                    JOIN wr.owner o
-                    WHERE (:active IS NULL OR wr.isActive = :active)
-                    AND (
-                        :query IS NULL
-                        OR LOWER(wr.name) LIKE LOWER(CONCAT('%', :query, '%'))
-                        OR LOWER(o.nickname) LIKE LOWER(CONCAT('%', :query, '%'))
-                    )
-                    """
-    )
+    @Query("""
+            SELECT wr
+            FROM WorkoutRoom wr
+            JOIN wr.owner o
+            WHERE (:active IS NULL OR wr.isActive = :active)
+            AND (
+                :query IS NULL
+                OR LOWER(wr.name) LIKE LOWER(CONCAT('%', :query, '%'))
+                OR LOWER(o.nickname) LIKE LOWER(CONCAT('%', :query, '%'))
+            )
+            """)
     Page<WorkoutRoom> searchAdminRooms(@Param("query") String query,
-                                       @Param("active") Boolean active,
-                                       Pageable pageable);
+            @Param("active") Boolean active,
+            Pageable pageable);
 
     List<WorkoutRoom> findByOwner(Member owner);
 
-    @Query(
-            """
-                    SELECT COUNT(wr)
-                    FROM WorkoutRoom wr
-                    WHERE wr.isActive = true
-                    AND (wr.endDate IS NULL OR wr.endDate >= :today)
-                    """
-    )
-    long countActiveRooms(@Param("today") LocalDate today);
+    @Query("""
+            SELECT COUNT(wr)
+            FROM WorkoutRoom wr
+            WHERE wr.isActive = true
+            """)
+    long countActiveRooms();
 }

--- a/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/workout/service/WorkoutRoomService.java
@@ -46,22 +46,10 @@ public class WorkoutRoomService {
     public WorkoutRoomResponse createWorkoutRoom(Member owner, CreateWorkoutRoomRequest request) {
         validateWorkoutRoomLimit(owner);
 
-        // 날짜 검증
-/*        if (request.getStartDate().isBefore(LocalDate.now())) {
-            throw new CustomException(ErrorCode.INVALID_INPUT, "시작 날짜는 오늘 이후여야 합니다.");
-        }
-        if (request.getEndDate() != null) {
-            if (request.getEndDate().isBefore(request.getStartDate())) {
-                throw new CustomException(ErrorCode.INVALID_INPUT, "종료 날짜는 시작 날짜보다 뒤여야 합니다.");
-            }
-        }*/
-
         WorkoutRoom workoutRoom = WorkoutRoom.builder()
                 .name(request.getName())
                 .minWeeklyWorkouts(request.getMinWeeklyWorkouts())
                 .penaltyPerMiss(request.getPenaltyPerMiss())
-                // .startDate(request.getStartDate())
-                // .endDate(request.getEndDate() != null ? request.getEndDate() : null)
                 .maxMembers(request.getMaxMembers())
                 .entryCode(request.getEntryCode())
                 .owner(owner)
@@ -69,7 +57,6 @@ public class WorkoutRoomService {
 
         WorkoutRoom savedWorkoutRoom = workoutRoomRepository.save(workoutRoom);
 
-        // 방장을 멤버로 추가
         WorkoutRoomMember workoutRoomMember = WorkoutRoomMember.builder()
                 .member(owner)
                 .workoutRoom(savedWorkoutRoom)
@@ -87,7 +74,6 @@ public class WorkoutRoomService {
     }
 
     @Transactional(readOnly = true)
-//    @Cacheable(value = "workoutRoomDetail", key = "#roomId + '-' + #member.id")
     public WorkoutRoomDetailResponse getJoinedWorkoutRoom(Long roomId, Member member) {
         WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
                 .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND, "유저가 속한 운동방이 없습니다."));

--- a/src/test/java/com/behcm/domain/admin/workout/controller/AdminWorkoutRoomControllerTest.java
+++ b/src/test/java/com/behcm/domain/admin/workout/controller/AdminWorkoutRoomControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -48,14 +47,11 @@ class AdminWorkoutRoomControllerTest {
     @WithMockUser(roles = "ADMIN")
     @DisplayName("ADMIN 권한으로 운동방 목록 조회 시 200과 ApiResponse.success가 반환된다")
     void getRooms_withAdminRole_returnsOk() throws Exception {
-        // given
         WorkoutRoomResponse roomResponse = WorkoutRoomResponse.builder()
                 .id(1L)
                 .name("Room 1")
                 .minWeeklyWorkouts(3)
                 .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusDays(10))
                 .maxMembers(10)
                 .currentMembers(1)
                 .isActive(true)
@@ -68,7 +64,6 @@ class AdminWorkoutRoomControllerTest {
         given(adminWorkoutRoomService.getRooms(anyString(), anyBoolean(), any(Pageable.class)))
                 .willReturn(page);
 
-        // when & then
         mockMvc.perform(get("/api/admin/workout/rooms")
                         .param("query", "Room")
                         .param("page", "0")
@@ -90,14 +85,11 @@ class AdminWorkoutRoomControllerTest {
     @WithMockUser(roles = "ADMIN")
     @DisplayName("ADMIN 권한으로 운동방 상세 조회 시 200과 ApiResponse.success가 반환된다")
     void getRoomDetail_withAdminRole_returnsOk() throws Exception {
-        // given
         WorkoutRoomResponse roomInfo = WorkoutRoomResponse.builder()
                 .id(1L)
                 .name("Room 1")
                 .minWeeklyWorkouts(3)
                 .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusDays(10))
                 .maxMembers(10)
                 .currentMembers(1)
                 .isActive(true)
@@ -109,7 +101,6 @@ class AdminWorkoutRoomControllerTest {
         given(adminWorkoutRoomService.getRoomDetail(anyLong()))
                 .willReturn(detailResponse);
 
-        // when & then
         mockMvc.perform(get("/api/admin/workout/rooms/{roomId}", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success", is(true)))
@@ -120,10 +111,7 @@ class AdminWorkoutRoomControllerTest {
     @WithMockUser(roles = "ADMIN")
     @DisplayName("ADMIN 권한으로 운동방 설정 수정 시 200과 수정된 정보가 반환된다")
     void updateRoomSettings_withAdminRole_returnsOk() throws Exception {
-        // given
         AdminUpdateRoomRequest request = new AdminUpdateRoomRequest();
-        request.setStartDate(LocalDate.now().plusDays(1));
-        request.setEndDate(LocalDate.now().plusDays(10));
         request.setMaxMembers(20);
         request.setMinWeeklyWorkouts(5);
         request.setPenaltyPerMiss(2000L);
@@ -133,8 +121,6 @@ class AdminWorkoutRoomControllerTest {
                 .name("Room 1")
                 .minWeeklyWorkouts(5)
                 .penaltyPerMiss(2000L)
-                .startDate(request.getStartDate())
-                .endDate(request.getEndDate())
                 .maxMembers(20)
                 .currentMembers(1)
                 .isActive(true)
@@ -143,7 +129,6 @@ class AdminWorkoutRoomControllerTest {
         given(adminWorkoutRoomService.updateRoomSettings(anyLong(), any(AdminUpdateRoomRequest.class)))
                 .willReturn(roomResponse);
 
-        // when & then
         mockMvc.perform(put("/api/admin/workout/rooms/{roomId}", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/behcm/domain/admin/workout/service/AdminWorkoutRoomServiceTest.java
+++ b/src/test/java/com/behcm/domain/admin/workout/service/AdminWorkoutRoomServiceTest.java
@@ -27,7 +27,6 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -58,14 +57,11 @@ class AdminWorkoutRoomServiceTest {
     @Test
     @DisplayName("getRooms는 레포지토리에서 조회한 WorkoutRoom 페이지를 WorkoutRoomResponse 페이지로 매핑한다")
     void getRooms_mapsToWorkoutRoomResponsePage() {
-        // given
         Pageable pageable = PageRequest.of(0, 10);
         WorkoutRoom room = WorkoutRoom.builder()
                 .name("Room 1")
                 .minWeeklyWorkouts(3)
                 .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now().plusDays(1))
-                .endDate(LocalDate.now().plusDays(10))
                 .maxMembers(10)
                 .entryCode("ENTRY01")
                 .owner(null)
@@ -75,11 +71,9 @@ class AdminWorkoutRoomServiceTest {
         given(workoutRoomRepository.searchAdminRooms(eq("query"), eq(true), eq(pageable)))
                 .willReturn(roomPage);
 
-        // when
         Page<WorkoutRoomResponse> result =
                 adminWorkoutRoomService.getRooms("query", true, pageable);
 
-        // then
         assertThat(result.getTotalElements()).isEqualTo(1);
         WorkoutRoomResponse response = result.getContent().getFirst();
         assertThat(response.getName()).isEqualTo(room.getName());
@@ -91,17 +85,14 @@ class AdminWorkoutRoomServiceTest {
     @Test
     @DisplayName("getRooms 호출 시 공백 query는 null로 정규화되어 레포지토리에 전달된다")
     void getRooms_normalizesBlankQueryToNull() {
-        // given
         Pageable pageable = PageRequest.of(0, 10);
         Page<WorkoutRoom> emptyPage = Page.empty(pageable);
         given(workoutRoomRepository.searchAdminRooms(isNull(), eq(null), eq(pageable)))
                 .willReturn(emptyPage);
 
-        // when
         Page<WorkoutRoomResponse> result =
                 adminWorkoutRoomService.getRooms("   ", null, pageable);
 
-        // then
         assertThat(result.getTotalElements()).isZero();
         verify(workoutRoomRepository).searchAdminRooms(null, null, pageable);
     }
@@ -109,10 +100,8 @@ class AdminWorkoutRoomServiceTest {
     @Test
     @DisplayName("getRoomDetail은 운동방이 존재하지 않으면 CustomException(WORKOUT_ROOM_NOT_FOUND)을 던진다")
     void getRoomDetail_whenRoomNotFound_throwsCustomException() {
-        // given
         given(workoutRoomRepository.findById(1L)).willReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> adminWorkoutRoomService.getRoomDetail(1L))
                 .isInstanceOf(CustomException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.WORKOUT_ROOM_NOT_FOUND);
@@ -121,13 +110,10 @@ class AdminWorkoutRoomServiceTest {
     @Test
     @DisplayName("getRoomDetail은 운동방, 멤버, 운동 기록, 휴식 정보를 조회해 WorkoutRoomDetailResponse로 반환한다")
     void getRoomDetail_returnsAggregatedDetailResponse() {
-        // given
         WorkoutRoom room = WorkoutRoom.builder()
                 .name("Room 1")
                 .minWeeklyWorkouts(3)
                 .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now().plusDays(1))
-                .endDate(LocalDate.now().plusDays(10))
                 .maxMembers(10)
                 .entryCode("ENTRY01")
                 .owner(null)
@@ -138,14 +124,14 @@ class AdminWorkoutRoomServiceTest {
                 .build();
 
         WorkoutRecord workoutRecord = WorkoutRecord.builder()
-                .workoutDate(LocalDate.now())
+                .workoutDate(java.time.LocalDate.now())
                 .duration(30)
                 .build();
 
         Rest rest = Rest.builder()
                 .reason("휴식")
-                .startDate(LocalDate.now())
-                .endDate(LocalDate.now().plusDays(1))
+                .startDate(java.time.LocalDate.now())
+                .endDate(java.time.LocalDate.now().plusDays(1))
                 .build();
 
         given(workoutRoomRepository.findById(1L)).willReturn(Optional.of(room));
@@ -156,10 +142,8 @@ class AdminWorkoutRoomServiceTest {
         given(restRepository.findAllByWorkoutRoomMember(workoutRoomMember))
                 .willReturn(List.of(rest));
 
-        // when
         WorkoutRoomDetailResponse result = adminWorkoutRoomService.getRoomDetail(1L);
 
-        // then
         assertThat(result.getWorkoutRoomInfo().getName()).isEqualTo(room.getName());
         assertThat(result.getWorkoutRoomMembers()).hasSize(1);
         WorkoutRoomMemberResponse memberResponse = result.getWorkoutRoomMembers().getFirst();
@@ -170,27 +154,22 @@ class AdminWorkoutRoomServiceTest {
         assertThat(workoutRecords.getFirst().getDuration()).isEqualTo(30);
         assertThat(restInfoList).hasSize(1);
         assertThat(restInfoList.getFirst().getReason()).isEqualTo("휴식");
-        assertThat(result.getCurrentMemberTodayWorkoutRecord()).isNull(); // 관리자 조회에서는 null
+        assertThat(result.getCurrentMemberTodayWorkoutRecord()).isNull();
     }
 
     @Test
     @DisplayName("updateRoomSettings는 유효한 요청에 대해 운동방 설정을 변경하고 저장된 결과를 반환한다")
     void updateRoomSettings_updatesRoomAndReturnsResponse() {
-        // given
         WorkoutRoom room = WorkoutRoom.builder()
                 .name("Room 1")
                 .minWeeklyWorkouts(3)
                 .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now().plusDays(1))
-                .endDate(LocalDate.now().plusDays(10))
                 .maxMembers(10)
                 .entryCode("ENTRY01")
                 .owner(null)
                 .build();
 
         AdminUpdateRoomRequest request = new AdminUpdateRoomRequest();
-        request.setStartDate(LocalDate.now().plusDays(2));
-        request.setEndDate(LocalDate.now().plusDays(20));
         request.setMaxMembers(20);
         request.setMinWeeklyWorkouts(5);
         request.setPenaltyPerMiss(2000L);
@@ -198,79 +177,14 @@ class AdminWorkoutRoomServiceTest {
         given(workoutRoomRepository.findById(1L)).willReturn(Optional.of(room));
         given(workoutRoomRepository.save(room)).willReturn(room);
 
-        // when
         WorkoutRoomResponse response = adminWorkoutRoomService.updateRoomSettings(1L, request);
 
-        // then
         assertThat(response.getMinWeeklyWorkouts()).isEqualTo(5);
         assertThat(response.getPenaltyPerMiss()).isEqualTo(2000L);
         assertThat(response.getMaxMembers()).isEqualTo(20);
 
         verify(workoutRoomRepository).findById(1L);
         verify(workoutRoomRepository).save(room);
-    }
-
-    @Test
-    @DisplayName("updateRoomSettings는 시작 날짜가 오늘보다 이전이면 CustomException(INVALID_INPUT)을 던진다")
-    void updateRoomSettings_whenStartDateBeforeToday_throwsCustomException() {
-        // given
-        WorkoutRoom room = WorkoutRoom.builder()
-                .name("Room 1")
-                .minWeeklyWorkouts(3)
-                .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now().plusDays(1))
-                .endDate(LocalDate.now().plusDays(10))
-                .maxMembers(10)
-                .entryCode("ENTRY01")
-                .owner(null)
-                .build();
-
-        AdminUpdateRoomRequest request = new AdminUpdateRoomRequest();
-        request.setStartDate(LocalDate.now().minusDays(1));
-        request.setEndDate(LocalDate.now().plusDays(10));
-        request.setMaxMembers(10);
-        request.setMinWeeklyWorkouts(3);
-        request.setPenaltyPerMiss(1000L);
-
-        given(workoutRoomRepository.findById(1L)).willReturn(Optional.of(room));
-
-        // when & then
-        assertThatThrownBy(() -> adminWorkoutRoomService.updateRoomSettings(1L, request))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
-    }
-
-    @Test
-    @DisplayName("updateRoomSettings는 종료 날짜가 시작 날짜보다 이전이면 CustomException(INVALID_INPUT)을 던진다")
-    void updateRoomSettings_whenEndDateBeforeStartDate_throwsCustomException() {
-        // given
-        WorkoutRoom room = WorkoutRoom.builder()
-                .name("Room 1")
-                .minWeeklyWorkouts(3)
-                .penaltyPerMiss(1000L)
-                .startDate(LocalDate.now().plusDays(1))
-                .endDate(LocalDate.now().plusDays(10))
-                .maxMembers(10)
-                .entryCode("ENTRY01")
-                .owner(null)
-                .build();
-
-        LocalDate startDate = LocalDate.now().plusDays(5);
-        LocalDate endDate = LocalDate.now().plusDays(1);
-
-        AdminUpdateRoomRequest request = new AdminUpdateRoomRequest();
-        request.setStartDate(startDate);
-        request.setEndDate(endDate);
-        request.setMaxMembers(10);
-        request.setMinWeeklyWorkouts(3);
-        request.setPenaltyPerMiss(1000L);
-
-        given(workoutRoomRepository.findById(1L)).willReturn(Optional.of(room));
-
-        // when & then
-        assertThatThrownBy(() -> adminWorkoutRoomService.updateRoomSettings(1L, request))
-                .isInstanceOf(CustomException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
     }
 }
 


### PR DESCRIPTION
Closes #108

## Description
- 운동방 도메인에서 startDate/endDate 필드를 제거하고 관련 DTO/서비스/테스트를 정리했습니다.
- 랜딩 통계의 활성 방 집계 로직을 날짜 파라미터 없이 동작하도록 수정했습니다.