### PR TITLE
관리자 운동방 채팅 내역 조회 API 추가

### DIFF
--- a/mdfiles/admin-room-chat-backend.md
+++ b/mdfiles/admin-room-chat-backend.md
@@ -1,0 +1,87 @@
+## 관리자 운동방 채팅 내역 조회 API
+
+관리자 화면(운동방 상세 → **채팅** 탭)에서 방 멤버들의 채팅 내역을 **읽기 전용**으로 조회하기 위한 API입니다.  
+멤버용 `GET /chat/rooms/{roomId}/messages`와 **동일한 응답 스키마**를 사용하며, **ADMIN 역할**만 호출할 수 있습니다.
+
+---
+
+## 1. 엔드포인트
+
+| 항목 | 내용 |
+|------|------|
+| Method / Path | `GET /api/admin/workout/rooms/{roomId}/messages` |
+| Auth | `ADMIN` 역할 필수 (`Authorization: Bearer …`) |
+| Path variable | `roomId` — 운동방 ID |
+| Query | `cursorId` (optional), `size` (optional, default `20`, max 권장 `50`) |
+
+### 1.1. Query 파라미터
+
+- `size`: 한 번에 가져올 메시지 개수 (기본 20)
+- `cursorId`: **더 오래된** 메시지 페이지 조회 시 사용. 멤버용 채팅 API와 동일한 커서 규칙을 따릅니다.
+  - 최초 요청: `cursorId` 생략 → 최신 `size`건
+  - 이전 대화: 응답의 `nextCursorId`를 다음 요청의 `cursorId`로 전달
+
+### 1.2. 권한
+
+- 요청자는 **방 멤버일 필요 없음** (관리자만 `ADMIN` 역할이면 됨).
+- `roomId`에 해당하는 운동방이 존재하지 않으면 `404`.
+- `ADMIN`이 아니면 `403`.
+
+---
+
+## 2. 응답 스키마
+
+프론트엔드 타입 (`src/types/index.ts`) 기준:
+
+```ts
+export interface ChatMessage {
+  id: string;
+  sender: string;
+  content: string;
+  timestamp: string;
+  type: 'TEXT' | 'IMAGE' | 'READ_STATUS' | 'SYSTEM';
+  imageUrl?: string;
+  unreadCount?: number;
+}
+
+export interface ChatHistoryResponse {
+  messages: ChatMessage[];
+  nextCursorId: number | null;
+  hasNext: boolean;
+}
+```
+
+### 2.1. 정렬 및 페이지네이션
+
+- **멤버용** `GET /chat/rooms/{roomId}/messages`와 동일한 정렬·커서 동작을 권장합니다.
+- 응답 `messages` 배열은 프론트에서 **오래된 순 → 최신 순**으로 표시하기 위해, 필요 시 클라이언트에서 재정렬하거나 API가 이미 시간순 오름차순이면 그대로 사용합니다.
+- `hasNext: true`이고 `nextCursorId`가 있으면, 더 오래된 메시지가 존재함.
+
+### 2.2. unreadCount (선택)
+
+- 관리자 조회 화면에서는 `unreadCount`를 표시하지 않지만, 스키마 호환을 위해 멤버 API와 동일하게 내려도 무방합니다.
+
+---
+
+## 3. 구현 참고
+
+- 메시지 저장소·조회 로직은 기존 채팅 도메인을 재사용하고, **인가(Authorization) 레이어만** `ADMIN` + `roomId` 검증으로 분리하는 방식이 적합합니다.
+- `READ_STATUS`, `SYSTEM` 타입 메시지는 프론트에서 목록에서 제외합니다 (`isSystemChatType`).
+
+---
+
+## 4. 프론트엔드 연동
+
+- API 클라이언트: `api.getAdminChatHistory(roomId, cursorId?, size?)`
+- UI: `src/components/admin/AdminRoomChatTab.tsx` (읽기 전용, WebSocket·전송 없음)
+
+---
+
+## 5. 에러 코드 (권장)
+
+| HTTP | 설명 |
+|------|------|
+| 200 | 성공 |
+| 403 | ADMIN 아님 |
+| 404 | `roomId` 없음 |
+| 401 | 미인증 |

--- a/src/main/java/com/behcm/domain/admin/workout/controller/AdminWorkoutRoomController.java
+++ b/src/main/java/com/behcm/domain/admin/workout/controller/AdminWorkoutRoomController.java
@@ -2,6 +2,7 @@ package com.behcm.domain.admin.workout.controller;
 
 import com.behcm.domain.admin.workout.dto.AdminUpdateRoomRequest;
 import com.behcm.domain.admin.workout.service.AdminWorkoutRoomService;
+import com.behcm.domain.chat.dto.ChatHistoryResponse;
 import com.behcm.domain.workout.dto.WorkoutRoomDetailResponse;
 import com.behcm.domain.workout.dto.WorkoutRoomResponse;
 import com.behcm.global.common.ApiResponse;
@@ -48,6 +49,16 @@ public class AdminWorkoutRoomController {
             @PathVariable Long roomId
     ) {
         WorkoutRoomDetailResponse response = adminWorkoutRoomService.getRoomDetail(roomId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{roomId}/messages")
+    public ResponseEntity<ApiResponse<ChatHistoryResponse>> getChatHistory(
+            @PathVariable Long roomId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        ChatHistoryResponse response = adminWorkoutRoomService.getChatHistory(roomId, cursorId, size);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/behcm/domain/admin/workout/service/AdminWorkoutRoomService.java
+++ b/src/main/java/com/behcm/domain/admin/workout/service/AdminWorkoutRoomService.java
@@ -1,7 +1,9 @@
 package com.behcm.domain.admin.workout.service;
 
 import com.behcm.domain.admin.workout.dto.AdminUpdateRoomRequest;
+import com.behcm.domain.chat.dto.ChatHistoryResponse;
 import com.behcm.domain.chat.repository.ChatMessageRepository;
+import com.behcm.domain.chat.service.ChatService;
 import com.behcm.domain.penalty.entity.Penalty;
 import com.behcm.domain.penalty.repository.PenaltyAccountRepository;
 import com.behcm.domain.penalty.repository.PenaltyRepository;
@@ -36,6 +38,7 @@ public class AdminWorkoutRoomService {
     private final WorkoutRecordRepository workoutRecordRepository;
     private final RestRepository restRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatService chatService;
     private final PenaltyAccountRepository penaltyAccountRepository;
     private final PenaltyRepository penaltyRepository;
 
@@ -62,6 +65,10 @@ public class AdminWorkoutRoomService {
                 .toList();
 
         return new WorkoutRoomDetailResponse(WorkoutRoomResponse.from(workoutRoom), workoutRoomMembers, null);
+    }
+
+    public ChatHistoryResponse getChatHistory(Long roomId, Long cursorId, int size) {
+        return chatService.getChatHistoryForAdmin(roomId, cursorId, size);
     }
 
     @Transactional

--- a/src/main/java/com/behcm/domain/chat/service/ChatService.java
+++ b/src/main/java/com/behcm/domain/chat/service/ChatService.java
@@ -96,18 +96,21 @@ public class ChatService {
         }
 
         // 2. 이전 기록 스크롤 로드
-        Pageable pageable = PageRequest.of(0, size);
-        Slice<ChatMessage> messageSlice = chatMessageRepository
-                .findByWorkoutRoomAndIdLessThanOrderByIdDesc(wrm.getWorkoutRoom(), cursorId, pageable);
+        return loadOlderMessages(wrm.getWorkoutRoom(), cursorId, size);
+    }
 
-        List<ChatMessage> chatMessages = messageSlice.getContent().stream()
-                .sorted(Comparator.comparing(ChatMessage::getId))
-                .toList();
+    @Transactional(readOnly = true)
+    public ChatHistoryResponse getChatHistoryForAdmin(Long roomId, Long cursorId, int size) {
+        WorkoutRoom workoutRoom = workoutRoomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.WORKOUT_ROOM_NOT_FOUND));
 
-        List<ChatMessageResponse> messages = toResponsesWithUnread(wrm.getWorkoutRoom(), chatMessages);
-        Long nextCursor = chatMessages.isEmpty() ? null : chatMessages.getFirst().getId();
+        int pageSize = Math.min(Math.max(size, 1), 50);
 
-        return new ChatHistoryResponse(messages, nextCursor, messageSlice.hasNext());
+        if (cursorId == null) {
+            return loadLatestMessages(workoutRoom, pageSize);
+        }
+
+        return loadOlderMessages(workoutRoom, cursorId, pageSize);
     }
 
     public void updateLastReadMessage(Member member, Long roomId) {
@@ -177,6 +180,37 @@ public class ChatService {
         Long nextCursor = oldMessages.isEmpty() ? null : oldMessages.getFirst().getId();
 
         return new ChatHistoryResponse(combinedResponses, nextCursor, oldMessageSlice.hasNext());
+    }
+
+    private ChatHistoryResponse loadOlderMessages(WorkoutRoom workoutRoom, Long cursorId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        Slice<ChatMessage> messageSlice = chatMessageRepository
+                .findByWorkoutRoomAndIdLessThanOrderByIdDesc(workoutRoom, cursorId, pageable);
+
+        List<ChatMessage> chatMessages = messageSlice.getContent().stream()
+                .sorted(Comparator.comparing(ChatMessage::getId))
+                .toList();
+
+        List<ChatMessageResponse> messages = toResponsesWithUnread(workoutRoom, chatMessages);
+        Long nextCursor = chatMessages.isEmpty() ? null : chatMessages.getFirst().getId();
+
+        return new ChatHistoryResponse(messages, nextCursor, messageSlice.hasNext());
+    }
+
+    private ChatHistoryResponse loadLatestMessages(WorkoutRoom workoutRoom, int size) {
+        Pageable pageable = PageRequest.of(0, size + 1);
+        List<ChatMessage> descMessages = chatMessageRepository.findByWorkoutRoomOrderByIdDesc(workoutRoom, pageable);
+
+        boolean hasNext = descMessages.size() > size;
+        List<ChatMessage> chatMessages = descMessages.stream()
+                .limit(size)
+                .sorted(Comparator.comparing(ChatMessage::getId))
+                .toList();
+
+        List<ChatMessageResponse> messages = toResponsesWithUnread(workoutRoom, chatMessages);
+        Long nextCursor = chatMessages.isEmpty() ? null : chatMessages.getFirst().getId();
+
+        return new ChatHistoryResponse(messages, nextCursor, hasNext);
     }
 
     private List<ChatMessageResponse> toResponsesWithUnread(WorkoutRoom workoutRoom, List<ChatMessage> messages) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,10 +23,10 @@ spring:
 cloud:
   aws:
     credentials:
-      access-key: ENC(vZ/NolroRR+tqNJoGqwNtr920TySD+JKw5C+b6fGoeY=)
-      secret-key: ENC(yTqkdKxGuimUAOyoRJdsxTOW0tqT1+JBIm7LW/H/DFw9QTgHGueiHVkl0CyFcatK9WwO+lVC6yc=)
+      access-key: ENC(SPPzrqWgyXUXVTcgjkyUpRu3M1WMigX4naC5pEWqHt0=)
+      secret-key: ENC(cB07qYeqVSis0WKZqqoOsLhNc+Hes1hJnhHbBIflyGMLQRmVDLno7Ne9poRh3DGT7D1vwwKHo5Q=)
     s3:
-      bucket: ENC(LBQ0Oiwmr4kfUXFudgnSPCzrVao1uhk9)
+      bucket: ENC(6V5nfAzhQgBTFIntlqAi03ssLAzppMvX)
     region:
       static: ap-northeast-2
 

--- a/src/test/java/com/behcm/domain/admin/workout/controller/AdminWorkoutRoomControllerTest.java
+++ b/src/test/java/com/behcm/domain/admin/workout/controller/AdminWorkoutRoomControllerTest.java
@@ -2,6 +2,7 @@ package com.behcm.domain.admin.workout.controller;
 
 import com.behcm.domain.admin.workout.dto.AdminUpdateRoomRequest;
 import com.behcm.domain.admin.workout.service.AdminWorkoutRoomService;
+import com.behcm.domain.chat.dto.ChatHistoryResponse;
 import com.behcm.domain.workout.dto.WorkoutRoomDetailResponse;
 import com.behcm.domain.workout.dto.WorkoutRoomResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -105,6 +106,29 @@ class AdminWorkoutRoomControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success", is(true)))
                 .andExpect(jsonPath("$.data.workoutRoomInfo.name", is("Room 1")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("ADMIN 권한으로 운동방 채팅 내역 조회 시 200과 ApiResponse.success가 반환된다")
+    void getChatHistory_withAdminRole_returnsOk() throws Exception {
+        ChatHistoryResponse chatHistoryResponse = new ChatHistoryResponse(Collections.emptyList(), null, false);
+
+        given(adminWorkoutRoomService.getChatHistory(eq(1L), isNull(), eq(20)))
+                .willReturn(chatHistoryResponse);
+
+        mockMvc.perform(get("/api/admin/workout/rooms/{roomId}/messages", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.hasNext", is(false)));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("ADMIN 권한이 아닌 사용자로 운동방 채팅 내역 조회 시 403이 반환된다")
+    void getChatHistory_withNonAdminRole_returnsForbidden() throws Exception {
+        mockMvc.perform(get("/api/admin/workout/rooms/{roomId}/messages", 1L))
+                .andExpect(status().isForbidden());
     }
 
     @Test


### PR DESCRIPTION
Closes #112

## Description

관리자 화면에서 운동방 채팅 내역을 읽기 전용으로 조회할 수 있는 API를 추가했습니다.

### 주요 변경
- `GET /api/admin/workout/rooms/{roomId}/messages` 엔드포인트 추가 (ADMIN 전용)
- `ChatService.getChatHistoryForAdmin()` — 멤버 여부 없이 roomId 기반 조회, 커서 페이지네이션 지원
- `loadOlderMessages` / `loadLatestMessages`로 채팅 조회 로직 공통화
- 컨트롤러 단위 테스트 추가 (ADMIN 200, 비관리자 403)
- API 스펙 문서 (`mdfiles/admin-room-chat-backend.md`) 추가